### PR TITLE
feat/#12: 회원가입 api 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,9 @@ dependencies {
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-//	// Spring Security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
-//	testImplementation 'org.springframework.security:spring-security-test'
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 }

--- a/src/main/java/com/haru/api/HaruApiApplication.java
+++ b/src/main/java/com/haru/api/HaruApiApplication.java
@@ -2,9 +2,10 @@ package com.haru.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
 public class HaruApiApplication {
 

--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.haru.api.domain.user.controller;
+
+import com.haru.api.domain.user.converter.UserConverter;
+import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.service.UserCommandService;
+import com.haru.api.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserCommandService userCommandService;
+
+    @Operation(summary = "회원가입", description =
+            "# 회원가입 API 입니다. 이메일과 패스워드 그리고 이름을 body에 입력해주세요."
+    )
+    @PostMapping("/signup")
+    public ApiResponse<Object> signUp(
+            @RequestBody @Valid UserRequestDTO.SignUpRequest request
+    ) {
+        userCommandService.signUp(request);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
@@ -1,0 +1,15 @@
+package com.haru.api.domain.user.converter;
+
+import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.entity.Users;
+import com.haru.api.domain.user.entity.enums.Status;
+
+public class UserConverter {
+    public static Users toUsers(UserRequestDTO.SignUpRequest request) {
+        return Users.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .status(Status.ACTIVE)
+                .build();
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
@@ -1,0 +1,21 @@
+package com.haru.api.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserRequestDTO {
+    @Getter
+    @Builder
+    public static class SignUpRequest {
+        @NotBlank(message = "이메일은 빈값일 수 없습니다.")
+        private String email;
+        @NotBlank(message = "비밀번호는 빈값일 수 없습니다.")
+        private String password;
+        @NotBlank(message = "이름은 빈값일 수 없습니다.")
+        private String name;
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
@@ -1,0 +1,4 @@
+package com.haru.api.domain.user.dto;
+
+public class UserResponseDTO {
+}

--- a/src/main/java/com/haru/api/domain/user/entity/Users.java
+++ b/src/main/java/com/haru/api/domain/user/entity/Users.java
@@ -40,4 +40,8 @@ public class Users extends BaseEntity {
     private String profileImage;
 
     private LocalDateTime inactiveDate;
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.haru.api.domain.user.repository;
+
+import com.haru.api.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<Users, Long> {
+}

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -1,0 +1,9 @@
+package com.haru.api.domain.user.service;
+
+import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.entity.Users;
+import jakarta.validation.Valid;
+
+public interface UserCommandService {
+    void signUp(UserRequestDTO.SignUpRequest request);
+}

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,23 @@
+package com.haru.api.domain.user.service;
+
+import com.haru.api.domain.user.converter.UserConverter;
+import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.entity.Users;
+import com.haru.api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService{
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signUp(UserRequestDTO.SignUpRequest request) {
+        Users user = UserConverter.toUsers(request);
+        user.encodePassword(passwordEncoder.encode(request.getPassword()));
+        userRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/haru/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/haru/api/global/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.haru.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #12

## 📝작업 내용
> 회원가입 api 구현 완료
> Spring Security의 BCryptPasswordEncoder클래스를 사용하여 비밀번호를 암호화하기 위해 SecurityConfig작성

## 🔎코드 설명(스크린샷(선택))
> user패키지에  controller, converter, dto, repository, service하위 패키지 추가하여 회원가입 api 구현
> request body에 email, password, name입력 시 회원가입 되도록 구현
> 회원가입 api구현 중 Spring Security에서 제공하는 BCryptPasswordEncoder클래스를 활용해 비밀번호 암호화하여 저장
> Spring Security의 기본 로그인 화면 제거하기 위해 HaruApiApplication.java 클래스파일의 @SpringBootApplication어노테이션에 (exclude = SecurityAutoConfiguration.class옵션 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
