### PR TITLE
feat/#10: 회원 정보 조회 API 구현 완료

### DIFF
--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -1,22 +1,22 @@
 package com.haru.api.domain.user.controller;
 
-import com.haru.api.domain.user.converter.UserConverter;
 import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.dto.UserResponseDTO;
 import com.haru.api.domain.user.service.UserCommandService;
+import com.haru.api.domain.user.service.UserQueryService;
 import com.haru.api.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
 public class UserController {
+
     private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
 
     @Operation(summary = "회원가입", description =
             "# 회원가입 API 입니다. 이메일과 패스워드 그리고 이름을 body에 입력해주세요."
@@ -27,5 +27,16 @@ public class UserController {
     ) {
         userCommandService.signUp(request);
         return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "유저 정보 조회", description =
+            "# 유저 정보 조회 API 입니다. 현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
+    )
+    @GetMapping("/{userId}/info")
+    public ApiResponse<UserResponseDTO.UserDTO> getUserInfo(
+            @PathVariable Long userId
+    ) {
+        UserResponseDTO.UserDTO userDTO = userQueryService.getUserInfo(userId);
+        return ApiResponse.onSuccess(userDTO);
     }
 }

--- a/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
@@ -1,6 +1,7 @@
 package com.haru.api.domain.user.converter;
 
 import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.dto.UserResponseDTO;
 import com.haru.api.domain.user.entity.Users;
 import com.haru.api.domain.user.entity.enums.Status;
 
@@ -10,6 +11,14 @@ public class UserConverter {
                 .email(request.getEmail())
                 .name(request.getName())
                 .status(Status.ACTIVE)
+                .build();
+    }
+
+    public static UserResponseDTO.UserDTO toUserDTO(Users users) {
+        return UserResponseDTO.UserDTO.builder()
+                .id(users.getId())
+                .email(users.getEmail())
+                .name(users.getName())
                 .build();
     }
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
@@ -1,4 +1,15 @@
 package com.haru.api.domain.user.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+
 public class UserResponseDTO {
+
+    @Getter
+    @Builder
+    public static class UserDTO {
+        private Long id;
+        private String email;
+        private String name;
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserQueryService.java
@@ -1,0 +1,7 @@
+package com.haru.api.domain.user.service;
+
+import com.haru.api.domain.user.dto.UserResponseDTO;
+
+public interface UserQueryService {
+    UserResponseDTO.UserDTO getUserInfo(Long userId);
+}

--- a/src/main/java/com/haru/api/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package com.haru.api.domain.user.service;
+
+import com.haru.api.domain.user.converter.UserConverter;
+import com.haru.api.domain.user.dto.UserResponseDTO;
+import com.haru.api.domain.user.entity.Users;
+import com.haru.api.domain.user.repository.UserRepository;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserResponseDTO.UserDTO getUserInfo(Long userId) {
+
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return UserConverter.toUserDTO(user);
+    }
+}

--- a/src/main/java/com/haru/api/global/apiPayload/exception/handler/MemberHandler.java
+++ b/src/main/java/com/haru/api/global/apiPayload/exception/handler/MemberHandler.java
@@ -1,0 +1,11 @@
+package com.haru.api.global.apiPayload.exception.handler;
+
+import com.haru.api.global.apiPayload.code.BaseErrorCode;
+import com.haru.api.global.apiPayload.exception.GeneralException;
+
+public class MemberHandler extends GeneralException {
+
+    public MemberHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #10

## 📝작업 내용
> - 회원 정보 조회 API 구현 완료
> - UserQueryService, UserQueryServiceImpl 생성 및 구현

## 🔎코드 설명(스크린샷(선택))
> - jwt token이 구현되지 않아 임시로 pathvariable을 통해서 userId를 받도록 구현
> - UserQueryService, UserQueryServiceImpl 클래스를 선언하여 GET 요청을 처리하는 service 클래스 구현
> - userId를 통해 조회했을 때 user가 조회되지 않으면 'MEMBER4001: 사용자가 없습니다'예외를 던지도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
