### PR TITLE
feat/#17: 회원 정보 수정 API 구현 완료

### DIFF
--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -26,17 +26,32 @@ public class UserController {
             @RequestBody @Valid UserRequestDTO.SignUpRequest request
     ) {
         userCommandService.signUp(request);
+
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "유저 정보 조회", description =
-            "# 유저 정보 조회 API 입니다. 현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
+    @Operation(summary = "회원 정보 조회", description =
+            "# 회원 정보 조회 API 입니다. 현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
     )
     @GetMapping("/{userId}/info")
     public ApiResponse<UserResponseDTO.UserDTO> getUserInfo(
             @PathVariable Long userId
     ) {
         UserResponseDTO.UserDTO userDTO = userQueryService.getUserInfo(userId);
+
+        return ApiResponse.onSuccess(userDTO);
+    }
+
+    @Operation(summary = "회원 정보 수정", description =
+            "# 회원 정보 수정 API 입니다. 현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
+    )
+    @PatchMapping("/{userId}/info")
+    public ApiResponse<UserResponseDTO.UserDTO> updateUserInfo(
+            @PathVariable Long userId,
+            @RequestBody @Valid UserRequestDTO.UserInfoUpdateRequest request
+    ) {
+        UserResponseDTO.UserDTO userDTO = userCommandService.updateUserInfo(userId, request);
+
         return ApiResponse.onSuccess(userDTO);
     }
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
@@ -18,4 +18,11 @@ public class UserRequestDTO {
         @NotBlank(message = "이름은 빈값일 수 없습니다.")
         private String name;
     }
+
+    @Getter
+    @Builder
+    public static class UserInfoUpdateRequest {
+        @NotBlank(message = "이름은 빈 값일 수 없습니다.")
+        private String name;
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/entity/Users.java
+++ b/src/main/java/com/haru/api/domain/user/entity/Users.java
@@ -24,6 +24,7 @@ public class Users extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, length = 20)
+    @Setter
     private String name;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -1,9 +1,10 @@
 package com.haru.api.domain.user.service;
 
 import com.haru.api.domain.user.dto.UserRequestDTO;
-import com.haru.api.domain.user.entity.Users;
-import jakarta.validation.Valid;
+import com.haru.api.domain.user.dto.UserResponseDTO;
 
 public interface UserCommandService {
     void signUp(UserRequestDTO.SignUpRequest request);
+
+    UserResponseDTO.UserDTO updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -2,8 +2,11 @@ package com.haru.api.domain.user.service;
 
 import com.haru.api.domain.user.converter.UserConverter;
 import com.haru.api.domain.user.dto.UserRequestDTO;
+import com.haru.api.domain.user.dto.UserResponseDTO;
 import com.haru.api.domain.user.entity.Users;
 import com.haru.api.domain.user.repository.UserRepository;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -11,13 +14,24 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService{
+
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Override
     public void signUp(UserRequestDTO.SignUpRequest request) {
         Users user = UserConverter.toUsers(request);
         user.encodePassword(passwordEncoder.encode(request.getPassword()));
         userRepository.save(user);
     }
 
+    @Override
+    public UserResponseDTO.UserDTO updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request) {
+        String name = request.getName();
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        user.setName(name);
+
+        return UserConverter.toUserDTO(user);
+    }
 }


### PR DESCRIPTION


## #️⃣연관된 이슈
> #17

## 📝작업 내용
> 회원 정보 수정 API 구현 완료

## 🔎코드 설명(스크린샷(선택))
> - jwt token이 구현되지 않아 임시로 pathvariable을 통해서 userId를 받도록 구현
> - 유저의 이름을 수정하기 위해 Users 엔티티의 name 필드에 @Setter 추가
> - 유저 정보가 수정되면, 수정된 정보를 반환하도록 구현
> - userId를 통해 조회했을 때 user가 조회되지 않으면 'MEMBER4001: 사용자가 없습니다'예외를 던지도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X