### PR TITLE
feat/#19: 이메일로 회원 리스트 조회 API 구현 완료

### DIFF
--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -10,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -31,7 +33,8 @@ public class UserController {
     }
 
     @Operation(summary = "회원 정보 조회", description =
-            "# 회원 정보 조회 API 입니다. 현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
+            "# 회원 정보 조회 API 입니다. \n" +
+                    "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
     )
     @GetMapping("/{userId}/info")
     public ApiResponse<UserResponseDTO.UserDTO> getUserInfo(
@@ -43,7 +46,8 @@ public class UserController {
     }
 
     @Operation(summary = "회원 정보 수정", description =
-            "# 회원 정보 수정 API 입니다. 현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
+            "# 회원 정보 수정 API 입니다. \n" +
+                    "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
     )
     @PatchMapping("/{userId}/info")
     public ApiResponse<UserResponseDTO.UserDTO> updateUserInfo(
@@ -54,4 +58,20 @@ public class UserController {
 
         return ApiResponse.onSuccess(userDTO);
     }
+
+    @Operation(summary = "이메일로 회원 리스트 조회", description =
+            "# 유사한 이메일을 가진 회원을 최대 4명까지 조회하는 API 입니다. \n" +
+                    "workspace에서 회원을 초대할 때 사용할 기능입니다. \n" +
+                    "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
+    )
+    @GetMapping("{userId}/search")
+    public ApiResponse<List<UserResponseDTO.UserDTO>> searchUsers(
+            @PathVariable Long userId,
+            @RequestParam String email
+    ) {
+        List<UserResponseDTO.UserDTO> userDTOs = userQueryService.getSimilarEmailUsers(userId, email);
+
+        return ApiResponse.onSuccess(userDTOs);
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
@@ -10,6 +10,7 @@ public class UserResponseDTO {
     public static class UserDTO {
         private Long id;
         private String email;
+        private String imageUrl;
         private String name;
     }
 }

--- a/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
@@ -4,6 +4,10 @@ import com.haru.api.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
+
+    List<Users> findTop4UsersByEmailContainingIgnoreCase(String email);
 }

--- a/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
 
     List<Users> findTop4UsersByEmailContainingIgnoreCase(String email);
+
+    Optional<Users> findByEmail(String email);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserQueryService.java
@@ -2,6 +2,10 @@ package com.haru.api.domain.user.service;
 
 import com.haru.api.domain.user.dto.UserResponseDTO;
 
+import java.util.List;
+
 public interface UserQueryService {
     UserResponseDTO.UserDTO getUserInfo(Long userId);
+
+    List<UserResponseDTO.UserDTO> getSimilarEmailUsers(Long userId, String email);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserQueryServiceImpl.java
@@ -9,6 +9,8 @@ import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class UserQueryServiceImpl implements UserQueryService {
@@ -22,5 +24,23 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         return UserConverter.toUserDTO(user);
+    }
+
+    @Override
+    public List<UserResponseDTO.UserDTO> getSimilarEmailUsers(Long userId, String email) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<Users> users = userRepository.findTop4UsersByEmailContainingIgnoreCase(email);
+
+        return users.parallelStream()
+                .map(user -> UserResponseDTO.UserDTO.builder()
+                        .id(user.getId())
+                        .email(user.getEmail())
+                        .imageUrl(user.getProfileImage())
+                        .name(user.getName())
+                        .build())
+                .toList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #19

## 📝작업 내용
> 이메일로 회원 리스트 조회 API 구현
> 입력받은 문자열이 포함된 이메일을 가진 유저 최대 4명 조회하도록 구현

## 🔎코드 설명(스크린샷(선택))
> - jwt token이 구현되지 않아 임시로 pathvariable을 통해서 userId를 받도록 구현
> - userId를 통해 조회했을 때 user가 조회되지 않으면 'MEMBER4001: 사용자가 없습니다'예외를 던지도록 구현
> - query parameter로 email을 받도록 구현
> - 쿼리 메서드로 입력된 문자열이 포함된 이메일을 가진 유저 최대 4명을 조회하도록 구현
> - UserDTO에 imageUrl 필드 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X