### PR TITLE
Feat/#24 jwt토큰 생성 및 Spring Security를 활용한 토큰 검증(인가 처리) 구현 완료, access token갱신과 로그아웃 api 구현 완료

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
 
     env:
-      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
       JWT_ACCESS_EXP_TIME: ${{ secrets.JWT_ACCESS_EXP_TIME }}
       JWT_REFRESH_EXP_TIME: ${{ secrets.JWT_REFRESH_EXP_TIME }}
-      JWT_HEADER: ${{ secrets.JWT_HEADER }}
+      JWT_JWT_HEADER: ${{ secrets.JWT_JWT_HEADER }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,12 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
+      JWT_ACCESS_EXP_TIME: ${{ secrets.JWT_ACCESS_EXP_TIME }}
+      JWT_REFRESH_EXP_TIME: ${{ secrets.JWT_REFRESH_EXP_TIME }}
+      JWT_HEADER: ${{ secrets.JWT_HEADER }}
+
     steps:
       - uses: actions/checkout@v4
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
 
 	// h2 database for test
-	runtimeOnly 'com.h2database:h2'
+	testImplementation 'com.h2database:h2'
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,14 @@ dependencies {
 
 	// h2 database for test
 	runtimeOnly 'com.h2database:h2'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// GSON
+	implementation 'com.google.code.gson:gson:2.11.0'
 }
 
 dependencyManagement {

--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -55,6 +55,17 @@ public class UserController {
         );
     }
 
+    @Operation(summary = "로그아웃 API", description =
+            "# 로그아웃 API 입니다. 로그아웃하고자 하는 유저의 access token을 header에 입력해주세요."
+    )
+    @DeleteMapping("/logout")
+    public ApiResponse<?> logout(
+            @RequestHeader("Authorization") String accessToken
+    ) {
+        userCommandService.logout(accessToken);
+        return ApiResponse.onSuccess("");
+    }
+
     @Operation(summary = "회원 정보 조회", description =
             "# 회원 정보 조회 API 입니다. \n" +
                     "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."

--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -43,6 +43,18 @@ public class UserController {
         );
     }
 
+    @Operation(summary = "토큰 갱신", description =
+            "# access token 갱신 API 입니다. access token과 refresh token을 header에 입력해주세요."
+    )
+    @PostMapping("/refresh")
+    public ApiResponse<UserResponseDTO.RefreshResponse> refreshToken(
+            @RequestHeader("RefreshToken") String refreshToken
+    ) {
+        return ApiResponse.onSuccess(
+                userCommandService.refresh(refreshToken)
+        );
+    }
+
     @Operation(summary = "회원 정보 조회", description =
             "# 회원 정보 조회 API 입니다. \n" +
                     "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."

--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -35,11 +35,12 @@ public class UserController {
             "# 로그인 API 입니다. 이메일과 패스워드를 body에 입력해주세요."
     )
     @PostMapping("/login")
-    public ApiResponse<Object> login(
+    public ApiResponse<UserResponseDTO.LoginResponse> login(
             @RequestBody @Valid UserRequestDTO.LoginRequest request
     ) {
-        userCommandService.login(request);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess(
+                userCommandService.login(request)
+        );
     }
 
     @Operation(summary = "회원 정보 조회", description =

--- a/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
@@ -21,4 +21,12 @@ public class UserConverter {
                 .name(users.getName())
                 .build();
     }
+
+    public static UserResponseDTO.LoginResponse toLoginResponse(Users users, String accessToken, String refreshToken) {
+        return UserResponseDTO.LoginResponse.builder()
+                .userid(users.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
@@ -29,4 +29,12 @@ public class UserConverter {
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    public static UserResponseDTO.RefreshResponse toRefreshResponse(Long userId, String accessToken, String refreshToken) {
+        return UserResponseDTO.RefreshResponse.builder()
+                .userId(userId)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
@@ -21,4 +21,12 @@ public class UserResponseDTO {
         private String accessToken;
         private String refreshToken;
     }
+
+    @Getter
+    @Builder
+    public static class RefreshResponse {
+        private Long userId;
+        private String accessToken;
+        private String refreshToken;
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserResponseDTO.java
@@ -13,4 +13,12 @@ public class UserResponseDTO {
         private String imageUrl;
         private String name;
     }
+
+    @Getter
+    @Builder
+    public static class LoginResponse {
+        private Long userid;
+        private String accessToken;
+        private String refreshToken;
+    }
 }

--- a/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/haru/api/domain/user/repository/UserRepository.java
@@ -10,6 +10,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<Users, Long> {
     List<Users> findTop4UsersByEmailContainingIgnoreCase(String email); // <<< 이 부분은 내 브랜치에서 추가된 메서드
-
     Optional<Users> findByEmail(String email);
 }

--- a/src/main/java/com/haru/api/domain/user/security/jwt/CustomExpiredJwtException.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/CustomExpiredJwtException.java
@@ -1,0 +1,16 @@
+package com.haru.api.domain.user.security.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+
+public class CustomExpiredJwtException extends ExpiredJwtException {
+    private final String message;
+
+    public CustomExpiredJwtException(String message, ExpiredJwtException source) {
+        super(source.getHeader(), source.getClaims(), source.getMessage());
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/security/jwt/CustomJwtException.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/CustomJwtException.java
@@ -1,0 +1,7 @@
+package com.haru.api.domain.user.security.jwt;
+
+public class CustomJwtException extends RuntimeException {
+    public CustomJwtException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
@@ -64,7 +64,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String refreshToken = request.getHeader("refreshToken");
 
         // 특정 경로(토큰 갱신 api)에서만 Refresh Token 처리
-        if ("/users/refresh".equals(requestUri)) {
+        if ("/api/v1/users/refresh".equals(requestUri)) {
             if (refreshToken != null) {
                 try {
                     // access token 검증

--- a/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,150 @@
+package com.haru.api.domain.user.security.jwt;
+
+import com.google.gson.Gson;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PatternMatchUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j //???
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Value("${jwt.JWT_HEADER}")
+    private String jwtHeader;
+    private static final String[] whitelist = {
+            "/api/v1/users/signup",
+            "/api/v1/users/login",
+            "/swagger-ui/**",
+            "/v3/**",
+            "/users/admin/**"
+    };
+    private final JwtUtils jwtUtils;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static void checkAuthorizationHeader(String header) {
+        log.info("-------------------#@@@@@------------------");
+        if(header == null) {
+            throw new CustomJwtException("토큰이 전달되지 않았습니다");
+        } else if (!header.startsWith("Bearer ")) {
+            throw new CustomJwtException("Bearer 로 시작하지 않는 올바르지 않은 토큰 형식입니다");
+        }
+    }
+
+    // 필터를 거치지 않을 URL(로그인, 회원가입) 을 설정하고, true 를 return 하면 현재 필터를 건너뛰고 다음 필터로 이동
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        log.info("---------------$$$$$$------------------");
+        log.info("boolean: {}", PatternMatchUtils.simpleMatch(whitelist, requestURI));
+        log.info("requestURI: {}", requestURI);
+        return PatternMatchUtils.simpleMatch(whitelist, requestURI);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authHeader = request.getHeader(jwtHeader);
+
+        String requestUri = request.getRequestURI();
+        String refreshToken = request.getHeader("refreshToken");
+
+        // 특정 경로(토큰 갱신 api)에서만 Refresh Token 처리
+        if ("/users/refresh".equals(requestUri)) {
+            if (refreshToken != null) {
+                try {
+                    // access token 검증
+                    checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+                    String token = JwtUtils.getTokenFromHeader(authHeader);
+                    Claims claims = jwtUtils.validateTokenOnlySignature(token); // 토큰 검증
+                    Authentication authentication = jwtUtils.getAuthenticationFromExpiredAccessToken(token); // 사용자 인증 정보 생성
+                    SecurityContextHolder.getContext().setAuthentication(authentication); // 사용자 인증 정보 저장
+                    // refresh token 검증
+                    jwtUtils.validateRefreshToken(refreshToken); // 토큰 검증
+                    filterChain.doFilter(request, response);    // 다음 필터로 이동
+                } catch (Exception e) {
+                    Gson gson = new Gson();
+                    String json = "";
+                    if (e instanceof CustomExpiredJwtException) {
+                        json = gson.toJson(Map.of("Token_Expired", e.getMessage()));
+                    } else {
+                        json = gson.toJson(Map.of("error", e.getMessage()));
+                    }
+
+                    response.setContentType("application/json; charset=UTF-8");
+                    PrintWriter printWriter = response.getWriter();
+                    printWriter.println(json);
+                    printWriter.close();
+                }
+            }
+            return;
+        }
+
+        try {
+            log.info("------------------------------------------------------");
+            checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+            String accessToken = JwtUtils.getTokenFromHeader(authHeader);
+            jwtUtils.validateToken(accessToken); // 토큰 검증
+            jwtUtils.isTokenBlacklisted(authHeader); // 블랙리스트 확인 = 로그아웃된 회원인지 확인
+            log.info("------------------------------------------------------");
+        } catch (Exception e) {
+            Gson gson = new Gson();
+            String json = "";
+            if (e instanceof CustomExpiredJwtException) {
+                json = gson.toJson(Map.of("Token_Expired", e.getMessage()));
+            } else {
+                json = gson.toJson(Map.of("error", e.getMessage()));
+            }
+
+            response.setContentType("application/json; charset=UTF-8");
+            PrintWriter printWriter = response.getWriter();
+            printWriter.println(json);
+            printWriter.close();
+
+            return;
+        }
+        // accessToken != null 처리해주어야함.
+
+        log.info("--------------------------- JwtVerifyFilter ---------------------------");
+
+        try {
+            checkAuthorizationHeader(authHeader);   // header 가 올바른 형식인지 체크
+            String token = JwtUtils.getTokenFromHeader(authHeader);
+            jwtUtils.validateToken(token); // 토큰 검증
+            jwtUtils.isExpired(token); // 토큰 만료 검증
+
+            Authentication authentication = jwtUtils.getAuthentication(token); // 사용자 인증 정보 생성
+            log.info("authentication = {}", authentication);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            filterChain.doFilter(request, response);    // 다음 필터로 이동
+        } catch (Exception e) {
+            Gson gson = new Gson();
+            String json = "";
+            if (e instanceof CustomExpiredJwtException) {
+                json = gson.toJson(Map.of("Token_Expired", e.getMessage()));
+            } else {
+                json = gson.toJson(Map.of("error", e.getMessage()));
+            }
+
+            response.setContentType("application/json; charset=UTF-8");
+            PrintWriter printWriter = response.getWriter();
+            printWriter.println(json);
+            printWriter.close();
+        }
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/security/jwt/JwtUtils.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/JwtUtils.java
@@ -1,0 +1,45 @@
+package com.haru.api.domain.user.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    @Value("${jwt.secret}")
+    public String secretKey;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String generateToken(Map<String, Object> valueMap, int validTime) { // static 제거
+        SecretKey key = null;
+        try {
+            key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        } catch(Exception e){
+            throw new RuntimeException(e.getMessage());
+        }
+        return Jwts.builder()
+                .setHeader(Map.of("typ","JWT"))
+                .setClaims(valueMap)
+                .setIssuedAt(Date.from(ZonedDateTime.now().toInstant()))
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(validTime).toInstant()))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/security/jwt/SecurityUtil.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/SecurityUtil.java
@@ -1,0 +1,23 @@
+package com.haru.api.domain.user.security.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+public class SecurityUtil {
+
+    private SecurityUtil() { }
+
+    // SecurityContext 에 유저 정보가 저장되는 시점
+    // Request 가 들어올 때 JwtAuthenticationFilter 의 doFilterInternal 에서 저장
+    public static Long getCurrentUserId() {
+        final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || authentication.getName() == null) {
+            throw  new RuntimeException("Security Context 에 인증 정보가 없습니다.");
+        }
+
+        return Long.parseLong(authentication.getName());
+    }
+}

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -10,4 +10,6 @@ public interface UserCommandService {
     UserResponseDTO.UserDTO updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request);
 
     UserResponseDTO.RefreshResponse refresh(String refreshToken);
+
+    void logout(String accessToken);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -5,7 +5,7 @@ import com.haru.api.domain.user.dto.UserResponseDTO;
 
 public interface UserCommandService {
     void signUp(UserRequestDTO.SignUpRequest request);
-    void login(UserRequestDTO.LoginRequest request);
+    UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request);
 
     UserResponseDTO.UserDTO updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -8,4 +8,6 @@ public interface UserCommandService {
     UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request);
 
     UserResponseDTO.UserDTO updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request);
+
+    UserResponseDTO.RefreshResponse refresh(String refreshToken);
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -5,23 +5,36 @@ import com.haru.api.domain.user.dto.UserRequestDTO;
 import com.haru.api.domain.user.dto.UserResponseDTO;
 import com.haru.api.domain.user.entity.Users;
 import com.haru.api.domain.user.repository.UserRepository;
+import com.haru.api.domain.user.security.jwt.JwtUtils;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 @Service
 @RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService{
 
+    @Value("${jwt.ACCESS_EXP_TIME}")
+    private int accessExpTime;
+    @Value("${jwt.REFRESH_EXP_TIME}")
+    private int refreshExpTime;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtUtils jwtUtils;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Override
     public void signUp(UserRequestDTO.SignUpRequest request) {
@@ -31,9 +44,17 @@ public class UserCommandServiceImpl implements UserCommandService{
     }
 
     @Override
-    public void login(UserRequestDTO.LoginRequest request) {
+    public UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // jwt토큰(access token, refresh token) 생성
+        Users getUser = userRepository.findByEmail(authentication.getName()).orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        String key = "users:" + getUser.getId().toString();
+        String accessToken = generateAccessToken(getUser.getId(), accessExpTime);
+        String refreshToken = generateAndSaveRefreshToken(key, refreshExpTime);
+
+        return UserConverter.toLoginResponse(getUser, accessToken, refreshToken);
     }
 
     @Override
@@ -45,5 +66,20 @@ public class UserCommandServiceImpl implements UserCommandService{
         user.setName(name);
 
         return UserConverter.toUserDTO(user);
+    }
+
+    private String generateAccessToken(Long userId, int accessExpTime) {
+        // 인증 완료 후 jwt토큰(accessToken) 생성
+        Map<String, Object> valueMap = Map.of(
+                "userId", userId
+        );
+        return jwtUtils.generateToken(valueMap, accessExpTime);
+    }
+
+    private String generateAndSaveRefreshToken(String key, int refreshExpTime) {
+        // 인증 완료 후 jwt토큰(refreshToken) 생성
+        String refreshToken = jwtUtils.generateToken(Collections.emptyMap(), refreshExpTime);
+        redisTemplate.opsForValue().set(key, refreshToken, refreshExpTime, TimeUnit.MINUTES);
+        return refreshToken;
     }
 }

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -81,6 +81,19 @@ public class UserCommandServiceImpl implements UserCommandService{
         return UserConverter.toRefreshResponse(userId, accessToken, newRefreshToken);
     }
 
+    @Override
+    public void logout(String accessToken) {
+        // 로그아웃시킬 회원의 refresh token redis에서 삭제
+        Long userId = SecurityUtil.getCurrentUserId();
+        String key = "users:" + userId.toString();
+        redisTemplate.delete(key);
+
+        // 로그아웃시킬 회원의 access token redis의 블랙리스트로 저장, 인가 처리시 블랙리스트 확인을 통해 로그아웃된 회원인지 확인함.
+        key = "blackList:" + userId.toString();
+        long tokenRemainTimeSecond = jwtUtils.tokenRemainTimeSecond(accessToken);
+        redisTemplate.opsForValue().set(key, accessToken, tokenRemainTimeSecond, TimeUnit.SECONDS);
+    }
+
 
     @Override
     @Transactional

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -23,6 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 회원 관려 에러 1000
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER1001", "사용자가 없습니다."),
+    REFRESHTOKEN_NOT_EQUAL(HttpStatus.BAD_REQUEST, "MEMBER1002", "리프레시 토큰이 일치하지 않습니다."),
 
     // 예시,,,
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -21,9 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
 
-    // 멤버 관려 에러
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    // 회원 관려 에러 1000
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER1001", "사용자가 없습니다."),
 
     // 예시,,,
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");

--- a/src/main/java/com/haru/api/global/config/RedisConfig.java
+++ b/src/main/java/com/haru/api/global/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.haru.api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        // 문자열 직렬화 설정
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        redisTemplate.setKeySerializer(stringSerializer);
+        redisTemplate.setValueSerializer(stringSerializer);
+        redisTemplate.setHashKeySerializer(stringSerializer);
+        redisTemplate.setHashValueSerializer(stringSerializer);
+
+        redisTemplate.afterPropertiesSet(); // 설정 반영
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,5 @@
 spring:
   config:
-    activate:
-      on-profile: local,green,blue
     import:
       - optional:classpath:application-secret.yml
       - optional:file:/app/config/application-secret.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 spring:
   config:
+    activate:
+      on-profile: local,green,blue
     import:
       - optional:classpath:application-secret.yml
       - optional:file:/app/config/application-secret.yml


### PR DESCRIPTION
## #️⃣연관된 이슈
> #24

## 📝작업 내용
1. jwt토큰 생성
  - access token과 refresh token생성, 유효시간은 각각 1시간과 2주
  - refresh token만 resdis에 저장

2. Spring Security를 활용한 토큰 검증(인가 처리) 구현 완료
  - 로그인과 회원가입 api를 제외한 api에서 토큰 검증하도록 구현
  - access token을 검증하고 access token 만료 시 refresh token으로 access token 갱신 api요청 보내야함

3. access token갱신 api구현 완료
  - access token, refresh token둘 다 갱신 후 반환

4. 로그아웃 api 구현 완료
  - redis에 블랙리스트로 추가

## 🔎코드 설명(스크린샷(선택))
1. jwt토큰 생성
> JwtUtils.java - 토큰 생성

2.  Spring Security를 활용한 토큰 검증(인가 처리)
> JwtAuthenticationFilter.java - Spring Security에 추가할 토큰 검증 필터

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
