### PR TITLE
feat/#31: 워크스페이스 리스트 제목 조회 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/userWorkspace/dto/UserWorkspaceWithTitleDTO.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/dto/UserWorkspaceWithTitleDTO.java
@@ -1,0 +1,18 @@
+package com.haru.api.domain.userWorkspace.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserWorkspaceWithTitleDTO {
+    private Long workspaceId;
+    private String title;
+    private Boolean isOwner;
+
+    public UserWorkspaceWithTitleDTO(Long workspaceId, String title, Boolean isOwner) {
+        this.workspaceId = workspaceId;
+        this.title = title;
+        this.isOwner = isOwner;
+    }
+}

--- a/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
@@ -1,7 +1,20 @@
 package com.haru.api.domain.userWorkspace.repository;
 
+import com.haru.api.domain.userWorkspace.dto.UserWorkspaceWithTitleDTO;
 import com.haru.api.domain.userWorkspace.entity.UserWorkspace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Long> {
+
+    @Query("SELECT new com.haru.api.domain.userWorkspace.dto.UserWorkspaceWithTitleDTO(" +
+            "uw.workspace.id, " +
+            "uw.workspace.title, " +
+            "CASE WHEN uw.user.id = uw.workspace.creator.id THEN true ELSE false END) " +
+            "FROM UserWorkspace uw " +
+            "WHERE uw.user.id = :userId")
+    List<UserWorkspaceWithTitleDTO> getUserWorkspacesWithTitle(@Param("userId") Long userId);
 }

--- a/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryService.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryService.java
@@ -1,0 +1,10 @@
+package com.haru.api.domain.userWorkspace.service;
+
+import com.haru.api.domain.userWorkspace.dto.UserWorkspaceWithTitleDTO;
+
+import java.util.List;
+
+public interface UserWorkspaceQueryService {
+
+    List<UserWorkspaceWithTitleDTO> getUserWorkspaceList(Long userId);
+}

--- a/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/service/UserWorkspaceQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.haru.api.domain.userWorkspace.service;
+
+import com.haru.api.domain.userWorkspace.dto.UserWorkspaceWithTitleDTO;
+import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserWorkspaceQueryServiceImpl implements UserWorkspaceQueryService {
+
+    private final UserWorkspaceRepository userWorkspaceRepository;
+
+    @Override
+    public List<UserWorkspaceWithTitleDTO> getUserWorkspaceList(Long userId) {
+
+        return userWorkspaceRepository.getUserWorkspacesWithTitle(userId);
+    }
+}

--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -1,6 +1,8 @@
 package com.haru.api.domain.workspace.controller;
 
 import com.haru.api.domain.user.security.jwt.SecurityUtil;
+import com.haru.api.domain.userWorkspace.dto.UserWorkspaceWithTitleDTO;
+import com.haru.api.domain.userWorkspace.service.UserWorkspaceQueryService;
 import com.haru.api.domain.workspace.dto.WorkspaceRequestDTO;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.service.WorkspaceCommandService;
@@ -9,12 +11,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/workspaces")
 public class WorkspaceController {
 
     private final WorkspaceCommandService workspaceCommandService;
+    private final UserWorkspaceQueryService userWorkspaceQueryService;
 
     @Operation(summary = "워크스페이스 생성", description =
             "# 워크스페이스 생성 API 입니다. 워크스페이스 제목과 초대하고자 하는 사람의 이메일을 입력해주세요."
@@ -29,6 +34,19 @@ public class WorkspaceController {
         WorkspaceResponseDTO.Workspace workspace = workspaceCommandService.createWorkspace(userId, request);
 
         return ApiResponse.onSuccess(workspace);
+    }
+
+    @Operation(summary = "워크스페이스 리스트 제목 조회", description =
+            "# 워크스페이스 리스트 제목 조회 API 입니다. jwt 토큰을 헤더에 넣어서 보내주세요"
+    )
+    @GetMapping("/me")
+    public ApiResponse<List<UserWorkspaceWithTitleDTO>> getWorkspaceWithTitleList() {
+
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        List<UserWorkspaceWithTitleDTO> workspaceWithTitleList = userWorkspaceQueryService.getUserWorkspaceList(userId);
+
+        return ApiResponse.onSuccess(workspaceWithTitleList);
     }
 
 }

--- a/src/main/java/com/haru/api/domain/workspace/entity/Workspace.java
+++ b/src/main/java/com/haru/api/domain/workspace/entity/Workspace.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.workspace.entity;
 
+import com.haru.api.domain.user.entity.Users;
 import com.haru.api.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -25,5 +26,9 @@ public class Workspace extends BaseEntity {
 
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id")
+    private Users creator;
 
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
@@ -30,8 +30,9 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         // workspace 생성 및 저장
-        Workspace workspace = workspaceRepository.save(com.haru.api.domain.workspace.entity.Workspace.builder()
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
                 .title(request.getName())
+                        .creator(foundUser)
                 .build());
 
 
@@ -39,7 +40,7 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
         // request로 받은 이메일로 초대 메일 전송하는 메서드
 
-        // user_workspace 테이블에 생성자 정보 저장
+        // users_workspaces 테이블에 생성자 정보 저장
         userWorkspaceRepository.save(UserWorkspace.builder()
                 .user(foundUser)
                 .workspace(workspace)
@@ -48,4 +49,6 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
 
         return WorkspaceConverter.toWorkspaceDTO(workspaceRepository.save(workspace));
     }
+
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #31

## 📝작업 내용
> Workspace entity에 creator 필드 추가
> 워크스페이스 생성할 때 생성자 id 추가하도록 수정
> JPQL에서 내부 클래스 DTO 생성이 안돼서 단일 DTO로 사용
> UserWorkspaceQueryService를 WorkspaceController에서 주입받아서 사용하도록 구현

## 🔎코드 설명(스크린샷(선택))
> WorkspaceController에서 UserWorkspaceQueryService를 주입받아서 사용하도록 구현
> UserWorkspaceRepository에서 JPQL을 사용해서 user_id가 현재 로그인한 유저의 id와 같은 컬럼을 추출하도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X