### PR TITLE
feat/#39: 워크스페이스 수정 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -8,6 +8,7 @@ import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.service.WorkspaceCommandService;
 import com.haru.api.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,7 +27,7 @@ public class WorkspaceController {
     )
     @PostMapping
     public ApiResponse<WorkspaceResponseDTO.Workspace> createWorkspace(
-            @RequestBody WorkspaceRequestDTO.WorkspaceCreateRequest request
+            @RequestBody @Valid WorkspaceRequestDTO.WorkspaceCreateRequest request
     ) {
 
         Long userId = SecurityUtil.getCurrentUserId();
@@ -37,7 +38,7 @@ public class WorkspaceController {
     }
 
     @Operation(summary = "워크스페이스 리스트 제목 조회", description =
-            "# 워크스페이스 리스트 제목 조회 API 입니다. jwt 토큰을 헤더에 넣어서 보내주세요"
+            "# 워크스페이스 리스트 제목 조회 API 입니다. jwt 토큰을 헤더에 넣어주세요"
     )
     @GetMapping("/me")
     public ApiResponse<List<UserWorkspaceWithTitleDTO>> getWorkspaceWithTitleList() {
@@ -47,6 +48,21 @@ public class WorkspaceController {
         List<UserWorkspaceWithTitleDTO> workspaceWithTitleList = userWorkspaceQueryService.getUserWorkspaceList(userId);
 
         return ApiResponse.onSuccess(workspaceWithTitleList);
+    }
+
+    @Operation(summary = "워크스페이스 수정", description =
+            "# 워크스페이스 수정 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    )
+    @PatchMapping("/{workspaceId}")
+    public ApiResponse<WorkspaceResponseDTO.Workspace> updateWorkspace(
+            @RequestBody @Valid WorkspaceRequestDTO.WorkspaceUpdateRequest request,
+            @PathVariable Long workspaceId
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        WorkspaceResponseDTO.Workspace workspace = workspaceCommandService.updateWorkspace(userId, workspaceId, request);
+
+        return ApiResponse.onSuccess(workspace);
     }
 
 }

--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -8,6 +8,7 @@ public class WorkspaceConverter {
         return WorkspaceResponseDTO.Workspace.builder()
                 .workspaceId(workspace.getId())
                 .name(workspace.getTitle())
+                .imageUrl(workspace.getImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceRequestDTO.java
@@ -15,4 +15,11 @@ public class WorkspaceRequestDTO {
         private String name;
         private List<String> memberEmails;
     }
+
+    @Getter
+    @Builder
+    public static class WorkspaceUpdateRequest {
+        @NotBlank(message = "수정하고자 하는 제목은 빈 값일 수 없습니다.")
+        private String title;
+    }
 }

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
@@ -10,5 +10,6 @@ public class WorkspaceResponseDTO {
     public static class Workspace {
         private Long workspaceId;
         private String name;
+        private String imageUrl;
     }
 }

--- a/src/main/java/com/haru/api/domain/workspace/entity/Workspace.java
+++ b/src/main/java/com/haru/api/domain/workspace/entity/Workspace.java
@@ -22,6 +22,7 @@ public class Workspace extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, length = 50)
+    @Setter
     private String title;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -6,4 +6,6 @@ import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 public interface WorkspaceCommandService {
 
     WorkspaceResponseDTO.Workspace createWorkspace(Long userId, WorkspaceRequestDTO.WorkspaceCreateRequest request);
+
+    WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceid, WorkspaceRequestDTO.WorkspaceUpdateRequest request);
 }

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -27,6 +27,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Workspace 관련 에러
     WORKSPACE_NOT_FOUND(HttpStatus.BAD_REQUEST,"WORKSPACE1001", "워크스페이스가 없습니다."),
+    WORKSPACE_MODIFY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "WORKSPACE1002", "워크스페이스 수정 권한이 없습니다."),
 
     // AI회의 Meetings 관련 에러
     MEETING_FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEETING1001", "안건지가 업로드되지 않았습니다."),

--- a/src/main/java/com/haru/api/global/apiPayload/exception/handler/WorkspaceHandler.java
+++ b/src/main/java/com/haru/api/global/apiPayload/exception/handler/WorkspaceHandler.java
@@ -1,0 +1,10 @@
+package com.haru.api.global.apiPayload.exception.handler;
+
+import com.haru.api.global.apiPayload.code.BaseErrorCode;
+import com.haru.api.global.apiPayload.exception.GeneralException;
+
+public class WorkspaceHandler extends GeneralException {
+    public WorkspaceHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #39

## 📝작업 내용
- WorkspaceHandler 추가
- WorkspaceResponseDTO에 imageUrl 필드 추가
- workspace 생성, 수정 서비스 메서드에 @Transactional 어노테이션 추가

## 🔎코드 설명(스크린샷(선택))
- workspace 수정 시에 우선 유저 조회, workspace 조회
- 만약 유저ID와 workspace 생성자의 ID가 다르면 예외 발생
- 같으면 entity 수정하고 EntityManager의 Dirty Checking에 의해 자동으로 수정

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
