### PR TITLE
feat/#41: 워크스페이스 초대 수락 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -65,4 +65,18 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(workspace);
     }
 
+    @Operation(summary = "워크스페이스 초대 수락", description =
+            "# 워크스페이스 초대 수락 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    )
+    @PostMapping("/workspaces/invite-accept")
+    public ApiResponse<?> acceptInvite(
+            @RequestParam("code") String code
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        workspaceCommandService.acceptInvite(userId, code);
+
+        return ApiResponse.onSuccess(null);
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -8,4 +8,6 @@ public interface WorkspaceCommandService {
     WorkspaceResponseDTO.Workspace createWorkspace(Long userId, WorkspaceRequestDTO.WorkspaceCreateRequest request);
 
     WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceid, WorkspaceRequestDTO.WorkspaceUpdateRequest request);
+
+    void acceptInvite(Long userId, String code);
 }

--- a/src/main/java/com/haru/api/domain/workspaceInvitation/entity/WorkspaceInvitation.java
+++ b/src/main/java/com/haru/api/domain/workspaceInvitation/entity/WorkspaceInvitation.java
@@ -1,0 +1,33 @@
+package com.haru.api.domain.workspaceInvitation.entity;
+
+import com.haru.api.domain.workspace.entity.Workspace;
+import com.haru.api.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Table(name = "workspace_invitations")
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WorkspaceInvitation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    Workspace workspace;
+
+    private String invitationCode;
+
+    @Setter
+    private Boolean isAccepted = false;
+}

--- a/src/main/java/com/haru/api/domain/workspaceInvitation/repository/WorkspaceInvitationRepository.java
+++ b/src/main/java/com/haru/api/domain/workspaceInvitation/repository/WorkspaceInvitationRepository.java
@@ -1,0 +1,10 @@
+package com.haru.api.domain.workspaceInvitation.repository;
+
+import com.haru.api.domain.workspaceInvitation.entity.WorkspaceInvitation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WorkspaceInvitationRepository extends JpaRepository<WorkspaceInvitation, Long> {
+    Optional<WorkspaceInvitation> findByInvitationCode(String invitationCode);
+}

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -32,6 +32,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // AI회의 Meetings 관련 에러
     MEETING_FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEETING1001", "안건지가 업로드되지 않았습니다."),
 
+    // workspace 초대 관련 에러
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITATION1001", "초대 코드에 해당하는 초대장이 존재하지 않습니다."),
+    EMAIL_MISMATCH(HttpStatus.BAD_REQUEST, "INVITATION1002", "초대장의 이메일과 현재 유저의 이메일이 일치하지 않습니다."),
+    ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "INVITATION1003", "이미 초대가 수락된 초대장입니다."),
+
     // 예시,,,
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다.");
 

--- a/src/main/java/com/haru/api/global/apiPayload/exception/handler/WorkspaceInvitationHandler.java
+++ b/src/main/java/com/haru/api/global/apiPayload/exception/handler/WorkspaceInvitationHandler.java
@@ -1,0 +1,10 @@
+package com.haru.api.global.apiPayload.exception.handler;
+
+import com.haru.api.global.apiPayload.code.BaseErrorCode;
+import com.haru.api.global.apiPayload.exception.GeneralException;
+
+public class WorkspaceInvitationHandler extends GeneralException {
+    public WorkspaceInvitationHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #41

## 📝작업 내용
- WorkspaceInvitation entity 추가
- 초대 관련 에러 추가(ALREADY_ACCEPTED, INVITATION_NOT_FOUND, EMAIL_MISMATCH)

## 🔎코드 설명(스크린샷(선택))
- WorkspaceInvitation entity 생성
- userId를 토대로 유저 찾고, 초대 코드로 invitation 검색
- 조회된 유저의 이메일과 invitation의 이메일이 다르면 예외 발생
- 이미 초대가 수락된 초대장이면 예외 발생
- 초대가 수락되면 invitation의 isAccepted를 true로 수정
- users_workspaces 테이블에 auth가 MEMBER로 데이터가 추가된다

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X