### PR TITLE
fix/#45: 회원 정보 수정 시 jwt token에서 userId 가져오도록 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -85,11 +85,12 @@ public class UserController {
             "# 회원 정보 수정 API 입니다. \n" +
                     "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
     )
-    @PatchMapping("/{userId}/info")
+    @PatchMapping("/info")
     public ApiResponse<UserResponseDTO.User> updateUserInfo(
-            @PathVariable Long userId,
             @RequestBody @Valid UserRequestDTO.UserInfoUpdateRequest request
     ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
         UserResponseDTO.User user = userCommandService.updateUserInfo(userId, request);
 
         return ApiResponse.onSuccess(user);

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -95,15 +95,17 @@ public class UserCommandServiceImpl implements UserCommandService{
     }
 
 
-    @Override
     @Transactional
+    @Override
     public UserResponseDTO.User updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request) {
         String name = request.getName();
-        Users user = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        user.setName(name);
 
-        return UserConverter.toUserDTO(user);
+        Users foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        foundUser.setName(name);
+
+        return UserConverter.toUserDTO(foundUser);
     }
 
     private String generateAccessToken(Long userId, int accessExpTime) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #45

## 📝작업 내용
> 회원 정보 수정 시 jwt token에서 userId 가져오도록 수정

## 🔎코드 설명(스크린샷(선택))
> X

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
