### PR TITLE
fix/#47: 이메일로 회원 리스트 조회 시 jwt token에서 userId 가져오도록 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/user/controller/UserController.java
+++ b/src/main/java/com/haru/api/domain/user/controller/UserController.java
@@ -101,11 +101,12 @@ public class UserController {
                     "workspace에서 회원을 초대할 때 사용할 기능입니다. \n" +
                     "현재는 jwt token을 구현하지 않아 pathvariable로 userId를 넣어주세요.추후 jwt token이 구현되면 수정하겠습니다."
     )
-    @GetMapping("{userId}/search")
+    @GetMapping("/search")
     public ApiResponse<List<UserResponseDTO.User>> searchUsers(
-            @PathVariable Long userId,
             @RequestParam String email
     ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
         List<UserResponseDTO.User> users = userQueryService.getSimilarEmailUsers(userId, email);
 
         return ApiResponse.onSuccess(users);


### PR DESCRIPTION
## #️⃣연관된 이슈
> #47

## 📝작업 내용
> 이메일로 회원 리스트 조회 시 jwt token에서 userId 가져오도록 수정

## 🔎코드 설명(스크린샷(선택))
> X

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X
