### PR TITLE
feat/#65 Meeting 조회api 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/haru/api/domain/meeting/controller/MeetingController.java
@@ -10,11 +10,10 @@ import com.haru.api.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/meetings")
@@ -23,6 +22,7 @@ public class MeetingController {
 
     private final MeetingService meetingService;
 
+    
     @PostMapping(
             consumes = {MediaType.MULTIPART_FORM_DATA_VALUE },
             produces = MediaType.APPLICATION_JSON_VALUE
@@ -38,6 +38,17 @@ public class MeetingController {
         Long userId = SecurityUtil.getCurrentUserId();
 
         MeetingResponseDTO.createMeetingResponse response = meetingService.createMeeting(userId, agendaFile, request);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/workspaces/{workspaceId}")
+    public ApiResponse<List<MeetingResponseDTO.getMeetingResponse>> getMeetings(
+            @PathVariable("workspaceId") Long workspaceId){
+
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        List<MeetingResponseDTO.getMeetingResponse> response = meetingService.getMeetings(userId, workspaceId);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/haru/api/domain/meeting/converter/MeetingConverter.java
+++ b/src/main/java/com/haru/api/domain/meeting/converter/MeetingConverter.java
@@ -4,6 +4,9 @@ import com.haru.api.domain.meeting.dto.MeetingResponseDTO;
 import com.haru.api.domain.meeting.entity.Meetings;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Component
 public class MeetingConverter {
 
@@ -12,7 +15,19 @@ public class MeetingConverter {
         return MeetingResponseDTO.createMeetingResponse.builder()
                 .meetingId(meeting.getId())
                 .title(meeting.getTitle())
-                .updatedAt(meeting.getCreatedAt())
                 .build();
     }
+
+    public static MeetingResponseDTO.getMeetingResponse toGetMeetingResponse(Meetings meeting, Long requesterId) {
+
+        boolean isCreator = meeting.getCreator().getId().equals(requesterId);
+
+        return MeetingResponseDTO.getMeetingResponse.builder()
+                .meetingId(meeting.getId())
+                .title(meeting.getTitle())
+                .isCreator(isCreator)
+                .updatedAt(meeting.getUpdatedAt())
+                .build();
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/meeting/dto/MeetingResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/meeting/dto/MeetingResponseDTO.java
@@ -1,6 +1,7 @@
 package com.haru.api.domain.meeting.dto;
 
-import com.haru.api.domain.meeting.entity.Meetings;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,9 +12,18 @@ public class MeetingResponseDTO {
     @Getter
     @Builder
     public static class createMeetingResponse{
-        private String title;
+        @JsonSerialize(using = ToStringSerializer.class)
         private Long meetingId;
-        private LocalDateTime updatedAt;
+        private String title;
+    }
 
+    @Getter
+    @Builder
+    public static class getMeetingResponse{
+        @JsonSerialize(using = ToStringSerializer.class)
+        private Long meetingId;
+        private String title;
+        private boolean isCreator;
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/haru/api/domain/meeting/entity/Meetings.java
+++ b/src/main/java/com/haru/api/domain/meeting/entity/Meetings.java
@@ -31,7 +31,7 @@ public class Meetings extends BaseEntity {
     private String proceeding;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+    private User creator;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Workspace workspaces;
@@ -39,7 +39,7 @@ public class Meetings extends BaseEntity {
     private Meetings(String title, String agendaResult, User user, Workspace workspaces) {
         this.title = title;
         this.agendaResult = agendaResult;
-        this.user = user;
+        this.creator = user;
         this.workspaces = workspaces;
     }
 

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface MeetingRepository extends JpaRepository<Meetings, Long> {
-    List<Meetings> findByWorkspaces(Workspace workspace);
+    List<Meetings> findByWorkspacesOrderByUpdatedAtDesc(Workspace workspace);
 }

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -1,9 +1,13 @@
 package com.haru.api.domain.meeting.repository;
 
 import com.haru.api.domain.meeting.entity.Meetings;
+import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MeetingRepository extends JpaRepository<Meetings, Long> {
+    List<Meetings> findByWorkspaces(Workspace workspace);
 }

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingService.java
@@ -4,7 +4,12 @@ import com.haru.api.domain.meeting.dto.MeetingRequestDTO;
 import com.haru.api.domain.meeting.dto.MeetingResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface MeetingService {
 
     public MeetingResponseDTO.createMeetingResponse createMeeting(Long userId, MultipartFile agendaFile, MeetingRequestDTO.createMeetingRequest request);
+
+    public List<MeetingResponseDTO.getMeetingResponse> getMeetings(Long userId, Long meetingId);
+
 }

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingServiceImpl.java
@@ -11,11 +11,14 @@ import com.haru.api.domain.workspace.entity.Workspace;
 import com.haru.api.domain.workspace.repository.WorkspaceRepository;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
-import com.haru.api.global.apiPayload.exception.handler.TempHandler;
+import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +40,7 @@ public class MeetingServiceImpl implements MeetingService{
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
         Workspace foundWorkspace = workspaceRepository.findById(request.getWorkspaceId())
-                .orElseThrow(() -> new TempHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
 
         // agendaFile을 openAi 활용하여 요약 - 미구현
         String agendaResult = "안건지 요약 - 미구현";
@@ -54,5 +57,20 @@ public class MeetingServiceImpl implements MeetingService{
 
 
         return MeetingConverter.toCreateMeetingResponse(savedMeeting);
+    }
+
+    @Override
+    public List<MeetingResponseDTO.getMeetingResponse> getMeetings(Long userId, Long workspaceId) {
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+
+        List<Meetings> foundMeetings = meetingRepository.findByWorkspaces(foundWorkspace);
+
+        return foundMeetings.stream()
+                .map(meeting -> MeetingConverter.toGetMeetingResponse(meeting, userId))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingServiceImpl.java
@@ -67,7 +67,7 @@ public class MeetingServiceImpl implements MeetingService{
         Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
                 .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
 
-        List<Meetings> foundMeetings = meetingRepository.findByWorkspaces(foundWorkspace);
+        List<Meetings> foundMeetings = meetingRepository.findByWorkspacesOrderByUpdatedAtDesc(foundWorkspace);
 
         return foundMeetings.stream()
                 .map(meeting -> MeetingConverter.toGetMeetingResponse(meeting, userId))


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #65 

## 📝작업 내용
>  Meeting 조회api 구현
Meeting 목록 조회시 최근 updatedAt기준으로 조회
JsonSerialize 어노테이션을 활용하여 responseDto에서 Long을 String으로 반환하도록 추가
## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
