### PR TITLE
Feat/#70 realtime stt implement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,23 @@ dependencies {
 
 	// GSON
 	implementation 'com.google.code.gson:gson:2.11.0'
+
+	// JSON
+	implementation("org.json:json:20240303")
+
+	// websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// http
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+
+	implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
+	// vad
+	implementation("com.orctom:vad4j:1.0")
+
+	// webflux
+	implementation("org.springframework.boot:spring-boot-starter-webflux:3.4.5")
 }
 
 dependencyManagement {

--- a/src/main/java/com/haru/api/domain/user/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/haru/api/domain/user/security/CustomAuthenticationProvider.java
@@ -14,13 +14,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CustomAuthenticationProvider implements AuthenticationProvider {
 
-    private final CustomDetailsService customDetailsSerivce;
+    private final CustomDetailsService customDetailsService;
     private final PasswordEncoder passwordEncoder;
 
     @Override
     public Authentication authenticate(Authentication authentication)
             throws AuthenticationException {
-        UserDetails userDetails = customDetailsSerivce.loadUserByUsername((String) authentication.getPrincipal(), (String) authentication.getCredentials());
+        UserDetails userDetails = customDetailsService.loadUserByUsername((String) authentication.getPrincipal(), (String) authentication.getCredentials());
 
         String password = authentication.getCredentials().toString();
         if (!passwordEncoder.matches(password, userDetails.getPassword())) {

--- a/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/users/login",
             "/swagger-ui/**",
             "/v3/**",
-            "/users/admin/**"
+            "/users/admin/**",
+            "/ws/audio"
     };
     private final JwtUtils jwtUtils;
     private final RedisTemplate<String, String> redisTemplate;

--- a/src/main/java/com/haru/api/domain/websocket/AudioProcessingQueue.java
+++ b/src/main/java/com/haru/api/domain/websocket/AudioProcessingQueue.java
@@ -1,0 +1,44 @@
+package com.haru.api.domain.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+@Slf4j
+public class AudioProcessingQueue {
+
+    private final Sinks.Many<byte[]> sink;
+    private final Flux<byte[]> flux;
+
+    public AudioProcessingQueue(Function<byte[], Mono<String>> sttFunction, WebSocketSession session) {
+        // 단일 소비자용 Sink 생성 (queue 기반)
+        this.sink = Sinks.many().unicast().onBackpressureBuffer();
+        this.flux = sink.asFlux();
+
+        // 비동기 순차 처리 시작
+        this.flux
+                .concatMap(buffer -> sttFunction.apply(buffer))
+                .subscribe(result -> {
+                    log.info("result: {}", result);
+//                    try {
+//                        session.sendMessage(new TextMessage(result));
+//                    } catch (IOException e) {
+//                        e.printStackTrace();
+//                    }
+                });
+    }
+
+    public void enqueue(byte[] buffer) {
+        Sinks.EmitResult result = sink.tryEmitNext(buffer);
+        if (result.isFailure()) {
+            // 실패 처리: 큐가 닫혔거나 오류 상태일 수 있음
+            System.err.println("Failed to enqueue audio buffer: " + result);
+        }
+    }
+}

--- a/src/main/java/com/haru/api/domain/websocket/AudioSessionBuffer.java
+++ b/src/main/java/com/haru/api/domain/websocket/AudioSessionBuffer.java
@@ -1,0 +1,58 @@
+package com.haru.api.domain.websocket;
+
+import java.io.ByteArrayOutputStream;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class AudioSessionBuffer {
+
+    private final ByteArrayOutputStream fullBuffer = new ByteArrayOutputStream();
+
+    private final ByteArrayOutputStream currentUtteranceBuffer = new ByteArrayOutputStream();
+
+    private final Queue<byte[]> audioQueue = new LinkedList<>();
+
+    // 상태
+    private boolean isTriggered = false;
+
+    private int noVoiceCount = 0;
+
+    public static final int NO_VOICE_COUNT_TARGET = 300;
+
+    public synchronized void appendFullBuffer(byte[] chunk) {
+        fullBuffer.write(chunk, 0, chunk.length);
+    }
+
+    public synchronized void appendCurrentUtteranceBuffer(byte[] chunk) {
+        currentUtteranceBuffer.write(chunk, 0, chunk.length);
+    }
+
+    public synchronized byte[] getAllBytes() {
+        return fullBuffer.toByteArray();
+    }
+
+    public synchronized byte[] getCurrentUtteranceBuffer() {
+        return currentUtteranceBuffer.toByteArray();
+    }
+
+    public synchronized void resetCurrentUtteranceBuffer() {
+        currentUtteranceBuffer.reset();
+    }
+
+    public synchronized boolean getIsTriggered() {
+        return isTriggered;
+    }
+
+    public synchronized void setIsTriggered(boolean isTriggered) {
+        this.isTriggered = isTriggered;
+    }
+
+    public synchronized int getNoVoiceCount() {
+        return noVoiceCount;
+    }
+
+    public synchronized void setNoVoiceCount(int noVoiceCount) {
+        this.noVoiceCount = noVoiceCount;
+    }
+
+}

--- a/src/main/java/com/haru/api/domain/websocket/AudioWebSocketHandler.java
+++ b/src/main/java/com/haru/api/domain/websocket/AudioWebSocketHandler.java
@@ -1,0 +1,103 @@
+package com.haru.api.domain.websocket;
+
+import com.orctom.vad4j.VAD;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.BinaryWebSocketHandler;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class AudioWebSocketHandler extends BinaryWebSocketHandler {
+
+    private final Map<String, AudioSessionBuffer> sessionBuffers = new ConcurrentHashMap<>();
+
+    private final FastApiClient fastApiClient = new FastApiClient();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        sessionBuffers.put(session.getId(), new AudioSessionBuffer());
+        System.out.println("WebSocket 연결됨: " + session.getId());
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        sessionBuffers.remove(session.getId());
+        System.out.println("연결 종료: " + session.getId());
+    }
+
+    @Override
+    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) {
+
+        // websocket 으로 넘겨받은 640 bytes 음성 chunk (20ms)
+        String sessionId = session.getId();
+        byte[] audioChunk = message.getPayload().array();
+
+        // session 의 sessionBuffer
+        AudioSessionBuffer sessionBuffer = sessionBuffers.get(sessionId);
+        if (sessionBuffer == null) return;
+
+        // 버퍼에 chunk 추가
+        sessionBuffer.appendFullBuffer(audioChunk);
+
+        // vad 사용해서 해당 chunk가 음성인지 판단
+        try (VAD vad = new VAD()) {
+            boolean isSpeech = vad.isSpeech(audioChunk);
+
+            boolean isTriggered = sessionBuffer.getIsTriggered();
+
+            // 음성 녹음 전
+            if (!isTriggered) {
+
+                // chunk가 음성인 경우
+                // 음성 버퍼에 데이터 저장
+                if(isSpeech) {
+                    sessionBuffer.appendCurrentUtteranceBuffer(audioChunk);
+                    sessionBuffer.setNoVoiceCount(0);
+                    sessionBuffer.setIsTriggered(true);
+                    log.info("isTriggered: {}", sessionBuffer.getIsTriggered());
+                }
+
+                // chunk가 음성이 아닌 경우
+                // 침묵이므로 아무것도 안함
+
+            } else { // 음성 녹음 중
+
+                // chunk가 음성인 경우
+                // 음성 버퍼에 데이터 저장
+                if(isSpeech) {
+                    sessionBuffer.appendCurrentUtteranceBuffer(audioChunk);
+                    sessionBuffer.setNoVoiceCount(0);
+                } else {
+                    // chunk가 음성이 아닌 경우
+                    // noVoiceCount 증가
+                    int noVoiceCount = sessionBuffer.getNoVoiceCount();
+                    sessionBuffer.setNoVoiceCount(noVoiceCount + 20);
+
+                    // noVoiceCount 가 임계값에 도달한 경우, 음성의 끝이라고 판단
+                    if (sessionBuffer.getNoVoiceCount() >= AudioSessionBuffer.NO_VOICE_COUNT_TARGET) {
+
+                        // stt api 호출
+                        //String result = sttService.transcribe(sessionBuffer.getCurrentUtteranceBuffer());
+                        //String result = fastApiClient.sendRawBytesToFastAPI(sessionBuffer.getCurrentUtteranceBuffer());
+                        log.info("speech detected");
+                        fastApiClient.sendRawBytesToFastAPI(sessionBuffer.getCurrentUtteranceBuffer())
+                                        .subscribe(result -> {
+                                            log.info("stt api 응답: {}", result);
+                                        });
+
+                        sessionBuffer.resetCurrentUtteranceBuffer();
+                        sessionBuffer.setIsTriggered(false);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/haru/api/domain/websocket/FastApiClient.java
+++ b/src/main/java/com/haru/api/domain/websocket/FastApiClient.java
@@ -1,0 +1,71 @@
+package com.haru.api.domain.websocket;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+public class FastApiClient {
+
+    private final String FASTAPI_URL = "http://localhost:8000/stt";
+
+    private final WebClient webClient;
+
+    public FastApiClient() {
+        this.webClient = WebClient.builder()
+                .baseUrl(FASTAPI_URL)
+                .build();
+    }
+
+    public Mono<String> sendRawBytesToFastAPI(byte[] audioBytes) {
+        return webClient.post()
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .bodyValue(audioBytes)
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(e -> {
+                    e.printStackTrace();
+                    return Mono.just("{\"error\": \"Failed to send\"}");
+                });
+    }
+
+//    public String sendRawBytesToFastAPI(byte[] audioBytes) {
+//        try (CloseableHttpClient client = HttpClients.createDefault()) {
+//            HttpPost post = new HttpPost(FASTAPI_URL);
+//            post.setEntity(new ByteArrayEntity(audioBytes, ContentType.APPLICATION_OCTET_STREAM));
+//
+//            try (CloseableHttpResponse response = client.execute(post)) {
+//                return EntityUtils.toString(response.getEntity());
+//            }
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            return "{\"error\": \"Failed to send\"}";
+//        }
+//    }
+
+//    @Override
+//    public boolean isVoice(byte[] audioChunk) {
+//        OkHttpClient client = new OkHttpClient();
+//
+//        RequestBody body = RequestBody.create(audioChunk, MediaType.parse("application/octet-stream"));
+//
+//        Request request = new Request.Builder()
+//                .url("http://localhost:8000/vad")  // FastAPI 주소
+//                .post(body)
+//                .build();
+//
+//        try (Response response = client.newCall(request).execute()) {
+//            if (!response.isSuccessful()) {
+//                System.err.println("VAD request failed: " + response);
+//                return false;
+//            }
+//
+//            String responseBody = response.body().string();
+//            JSONObject json = new JSONObject(responseBody);
+//            return json.getBoolean("is_voice");
+//        } catch (IOException e) {
+//            throw new RuntimeException(e);
+//        }
+//    }
+}

--- a/src/main/java/com/haru/api/domain/websocket/WavUtil.java
+++ b/src/main/java/com/haru/api/domain/websocket/WavUtil.java
@@ -1,0 +1,61 @@
+package com.haru.api.domain.websocket;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+public class WavUtil {
+
+    public static byte[] convertPcmToWav(byte[] pcmData, int sampleRate, int channels, int bitsPerSample) throws IOException {
+        int byteRate = sampleRate * channels * bitsPerSample / 8;
+        int blockAlign = channels * bitsPerSample / 8;
+        int dataSize = pcmData.length;
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        // RIFF header
+        out.write("RIFF".getBytes());
+        out.write(intToLittleEndian(36 + dataSize)); // file size - 8
+        out.write("WAVE".getBytes());
+
+        // fmt subchunk
+        out.write("fmt ".getBytes());
+        out.write(intToLittleEndian(16)); // Subchunk1Size (16 for PCM)
+        out.write(shortToLittleEndian((short) 1)); // AudioFormat (1 = PCM)
+        out.write(shortToLittleEndian((short) channels));
+        out.write(intToLittleEndian(sampleRate));
+        out.write(intToLittleEndian(byteRate));
+        out.write(shortToLittleEndian((short) blockAlign));
+        out.write(shortToLittleEndian((short) bitsPerSample));
+
+        // data subchunk
+        out.write("data".getBytes());
+        out.write(intToLittleEndian(dataSize));
+        out.write(pcmData);
+
+        return out.toByteArray();
+    }
+
+    public static void saveWavFile(String filePath, byte[] pcmData, int sampleRate, int channels, int bitsPerSample) throws IOException {
+        byte[] wavData = convertPcmToWav(pcmData, sampleRate, channels, bitsPerSample);
+        try (FileOutputStream fos = new FileOutputStream(filePath)) {
+            fos.write(wavData);
+        }
+    }
+
+    private static byte[] intToLittleEndian(int value) {
+        return new byte[] {
+                (byte)(value & 0xff),
+                (byte)((value >> 8) & 0xff),
+                (byte)((value >> 16) & 0xff),
+                (byte)((value >> 24) & 0xff)
+        };
+    }
+
+    private static byte[] shortToLittleEndian(short value) {
+        return new byte[] {
+                (byte)(value & 0xff),
+                (byte)((value >> 8) & 0xff)
+        };
+    }
+}

--- a/src/main/java/com/haru/api/global/config/WebSocketConfig.java
+++ b/src/main/java/com/haru/api/global/config/WebSocketConfig.java
@@ -1,0 +1,17 @@
+package com.haru.api.global.config;
+
+import com.haru.api.domain.websocket.AudioWebSocketHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class WebSocketConfig implements WebSocketConfigurer {
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(new AudioWebSocketHandler(), "/ws/audio")
+                .setAllowedOrigins("*");  // Cross-Origin 허용
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #70

## 📝작업 내용
> 실시간 stt 기능 구현

## 🔎코드 설명(스크린샷(선택))
- 클라이언트와 springboot 서버가 websocket으로 연결
- 클라이언트에서 16000hz로 샘플링된 20ms 단위의 audio chunk를 websocket을 통해서 서버로 계속해서 전송
- 모든 음성은 fullBuffer에 계속해서 저장
- 서버에서는 VAD 라이브러리를 통해서 각 audio chunk에 대해서 speech 여부를 판단
- speech라고 판단되면, currentBuffer에 저장
- 종단점이 판단되면 currentBuffer에 있는 audio chunk를 fastapi로 보내 stt api를 사용하여 반환받음

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X