### PR TITLE
feat/#82: last_opened 반정규화 엔티티 생성

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
@@ -1,0 +1,38 @@
+package com.haru.api.domain.lastOpened.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor
+public class UserDocumentId implements Serializable {
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "document_id")
+    private Long documentId;
+
+    public UserDocumentId(Long userId, Long documentId) {
+        this.userId = userId;
+        this.documentId = documentId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserDocumentId that)) return false;
+        return Objects.equals(userId, that.userId) &&
+                Objects.equals(documentId, that.documentId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, documentId);
+    }
+
+}

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
@@ -1,0 +1,41 @@
+package com.haru.api.domain.lastOpened.entity;
+
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+import com.haru.api.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_document_last_opened")
+@Getter
+@DynamicUpdate
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserDocumentLastOpened {
+
+    @EmbeddedId
+    private UserDocumentId id;
+
+    @Column(name = "document_id", nullable = false, insertable = false, updatable = false)
+    private Long documentId;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false,
+        foreignKey = @ForeignKey(name = "fk_user_document_user"))
+    private User user;
+
+    @Column(name = "last_opened", nullable = false)
+    private LocalDateTime lastOpened;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "document_type", length = 20, nullable = false)
+    private DocumentType documentType;
+
+}

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/enums/DocumentType.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/enums/DocumentType.java
@@ -1,0 +1,7 @@
+package com.haru.api.domain.lastOpened.entity.enums;
+
+public enum DocumentType {
+    AI_MEETING_MANAGER,
+    SNS_EVENT_ASSISTANT,
+    TEAM_MOOD_TRACKER
+}

--- a/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
@@ -1,0 +1,7 @@
+package com.haru.api.domain.lastOpened.repository;
+
+import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDocumentLastOpenedRepository extends JpaRepository<UserDocumentLastOpened, Long> {
+}


### PR DESCRIPTION


## #️⃣연관된 이슈
> #82

## 📝작업 내용
> last_opened 반정규화 엔티티 생성

## 🔎코드 설명(스크린샷(선택))
- userId, documentId 복합키를 위한 UserDocumentId 클래스 구현
- user_document_last_opened 테이블을 위한 UserDocumentLastOpened 엔티티 구현
- documentId는 그대로 사용하도록 하고, userId는 User에 외래키로 매핑되도록 구현
- DocumentType enum 생성
- 해당 클래스 repository 생성

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X