### PR TITLE
feat/#59: 팀 분위기 트래커 설문 링크 전송 & 설문 답변 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+	// Mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	implementation 'org.springframework.ai:spring-ai-pdf-document-reader'
 
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'

--- a/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
@@ -94,4 +94,35 @@ public class MoodTrackerController {
         return ApiResponse.of(SuccessStatus.MOOD_TRACKER_DELETED, null);
     }
 
+    @PostMapping("/{mood-tracker-id}/emails")
+    @Operation(
+            summary = "분위기 트래커 설문 링크 워크 스페이스 내의 팀원 email 전송 API",
+            description = "# 해당 ID의 분위기 트래커 설문 링크를 워크 스페이스 내의 유저에게 email로 전송합니다."
+    )
+    @Parameters({
+            @Parameter(name = "mood-tracker-id", description = "분위기 트래커 ID (Path Variable)", required = true)
+    })
+    public ApiResponse<Void> sendMoodTrackerSurveyLink(
+            @PathVariable(name = "mood-tracker-id") Long moodTrackerId
+    ) {
+        moodTrackerCommandService.sendSurveyLink(moodTrackerId);
+        return ApiResponse.of(SuccessStatus.MOOD_TRACKER_EMAIL_SENT, null);
+    }
+
+    @PostMapping("/{mood-tracker-id}/answer")
+    @Operation(
+            summary = "분위기 트래커 설문 답변 제출 API",
+            description = "# 해당 ID의 분위기 트래커 설문 답변을 제출합니다."
+    )
+    @Parameters({
+            @Parameter(name = "mood-tracker-id", description = "분위기 트래커 ID (Path Variable)", required = true)
+    })
+    public  ApiResponse<Void> submitMoodTrackerSurveyAnswers(
+            @PathVariable("mood-tracker-id") Long moodTrackerId,
+            @RequestBody MoodTrackerRequestDTO.SurveyAnswerList request
+    ) {
+        moodTrackerCommandService.submitSurveyAnswers(moodTrackerId, request);
+        return ApiResponse.of(SuccessStatus.MOOD_TRACKER_ANSWER_SUBMIT, null);
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/converter/MoodTrackerConverter.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/converter/MoodTrackerConverter.java
@@ -2,10 +2,7 @@ package com.haru.api.domain.moodTracker.converter;
 
 import com.haru.api.domain.moodTracker.dto.MoodTrackerRequestDTO;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
-import com.haru.api.domain.moodTracker.entity.CheckboxChoice;
-import com.haru.api.domain.moodTracker.entity.MoodTracker;
-import com.haru.api.domain.moodTracker.entity.MultipleChoice;
-import com.haru.api.domain.moodTracker.entity.SurveyQuestion;
+import com.haru.api.domain.moodTracker.entity.*;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.entity.Workspace;
 
@@ -88,5 +85,44 @@ public class MoodTrackerConverter {
         return MoodTrackerResponseDTO.CreateResult.builder()
                 .moodTrackerId(moodTracker.getId())
                 .build();
+    }
+
+    /**
+     * 주관식 답변 변환
+     */
+    public static SubjectiveAnswer toSubjectiveAnswer(
+            SurveyQuestion question,
+            String answerText
+    ) {
+        return SubjectiveAnswer.builder()
+                .surveyQuestion(question)
+                .answer(answerText)
+                .build();
+    }
+
+    /**
+     * 객관식 단답 (Multiple Choice) 변환
+     */
+    public static MultipleChoiceAnswer toMultipleChoiceAnswer(
+            MultipleChoice multipleChoice
+    ) {
+        return MultipleChoiceAnswer.builder()
+                    .multipleChoice(multipleChoice)
+                    .build();
+    }
+
+    /**
+     * 객관식 복수답 (Checkbox) 변환
+     */
+    public static List<CheckboxChoiceAnswer> toCheckboxChoiceAnswers(
+            List<CheckboxChoice> checkboxChoices
+    ) {
+        List<CheckboxChoiceAnswer> answers = new ArrayList<>();
+        for (CheckboxChoice checkboxChoice : checkboxChoices) {
+            answers.add(CheckboxChoiceAnswer.builder()
+                    .checkboxChoice(checkboxChoice)
+                    .build());
+        }
+        return answers;
     }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/dto/MoodTrackerRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/dto/MoodTrackerRequestDTO.java
@@ -39,7 +39,6 @@ public class MoodTrackerRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SurveyQuestion {
-
         @NotBlank
         private String title;
 
@@ -59,5 +58,31 @@ public class MoodTrackerRequestDTO {
     public static class UpdateTitleRequest {
         @NotBlank
         private String title;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SurveyAnswerList {
+        private List<SurveyAnswer> answers;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SurveyAnswer {
+        @NotNull
+        private Long questionId;
+
+        @NotNull
+        private QuestionType type;
+
+        private Long multipleChoiceId; // MULTI_CHOICE 는 1개
+
+        private List<Long> checkboxChoiceIdList; // CHECKBOX_CHOICE 는 여러 개; id 리스트로 받음
+
+        private String subjectiveAnswer; // SUBJECTIVE
     }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/MultipleChoiceAnswer.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/MultipleChoiceAnswer.java
@@ -5,9 +5,6 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Table(name = "multiple_choices_answer")
 @Getter

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/SubjectiveAnswer.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/SubjectiveAnswer.java
@@ -1,12 +1,14 @@
 package com.haru.api.domain.moodTracker.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Table(name = "subjective_answer")
-@Getter @Setter
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class SubjectiveAnswer {
 
     @Id

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/CheckboxChoiceAnswerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/CheckboxChoiceAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.haru.api.domain.moodTracker.repository;
+
+import com.haru.api.domain.moodTracker.entity.CheckboxChoiceAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CheckboxChoiceAnswerRepository extends JpaRepository<CheckboxChoiceAnswer, Long> {
+}

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MultipleChoiceAnswerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MultipleChoiceAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.haru.api.domain.moodTracker.repository;
+
+import com.haru.api.domain.moodTracker.entity.MultipleChoiceAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MultipleChoiceAnswerRepository extends JpaRepository<MultipleChoiceAnswer, Long> {
+}

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/SubjectiveAnswerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/SubjectiveAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.haru.api.domain.moodTracker.repository;
+
+import com.haru.api.domain.moodTracker.entity.SubjectiveAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubjectiveAnswerRepository extends JpaRepository<SubjectiveAnswer, Long> {
+}

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/SurveyQuestionRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/SurveyQuestionRepository.java
@@ -4,6 +4,9 @@ import com.haru.api.domain.moodTracker.entity.SurveyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SurveyQuestionRepository extends JpaRepository<SurveyQuestion, Long> {
+    List<SurveyQuestion> findAllByMoodTrackerId(Long moodTrackerId);
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandService.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandService.java
@@ -3,8 +3,6 @@ package com.haru.api.domain.moodTracker.service;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerRequestDTO;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
 
-import java.util.List;
-
 public interface MoodTrackerCommandService {
     MoodTrackerResponseDTO.CreateResult create(
             Long userId,
@@ -19,5 +17,12 @@ public interface MoodTrackerCommandService {
     void delete(
             Long userId,
             Long moodTrackerId
+    );
+    void sendSurveyLink(
+            Long moodTrackerId
+    );
+    void submitSurveyAnswers(
+            Long moodTrackerId,
+            MoodTrackerRequestDTO.SurveyAnswerList request
     );
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerMailService.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerMailService.java
@@ -1,0 +1,9 @@
+package com.haru.api.domain.moodTracker.service;
+
+public interface MoodTrackerMailService {
+    void sendSurveyLinkToEmail(
+            Long moodTrackerId,
+            String mailTitle,
+            String mailContent
+    );
+}

--- a/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
@@ -17,4 +17,7 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
             "FROM UserWorkspace uw " +
             "WHERE uw.user.id = :userId")
     List<UserWorkspaceResponseDTO.UserWorkspaceWithTitle> getUserWorkspacesWithTitle(@Param("userId") Long userId);
+
+    @Query("SELECT uw.user.email FROM UserWorkspace uw WHERE uw.workspace.id = :workspaceId")
+    List<String> findEmailsByWorkspaceId(@Param("workspaceId") Long workspaceId);
 }

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 분위기 트래커 관련 에러
     MOOD_TRACKER_NOT_FOUND(HttpStatus.BAD_REQUEST,"MOODTRACKER4001", "분위기 트래커가 없습니다."),
-    MOOD_TRACKER_MODIFY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "MOODTRACKER4002", "분위기 트래커에 권한이 없습니다."),;
+    MOOD_TRACKER_MODIFY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "MOODTRACKER4002", "분위기 트래커에 권한이 없습니다."),
+    SURVEY_QUESTION_NOT_FOUND(HttpStatus.BAD_REQUEST, "MOODTRACKER4003", "분위기 트래커 설문에 없는 질문입니다."),
+    SURVEY_ANSWER_REQUIRED(HttpStatus.BAD_REQUEST, "MOODTRACKER4004", "분위기 트래커 설문의 필수 응답이 누락되었습니다."),
+
+    // 메일 관련 에러
+    MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500", "이메일 전송에 실패했습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/SuccessStatus.java
@@ -17,7 +17,10 @@ public enum SuccessStatus implements BaseCode {
     // 분위기 트래커 성공 응답
     MOOD_TRACKER_CREATED(HttpStatus.CREATED, "MOODTRACKER201", "분위기 트래커 생성 성공"),
     MOOD_TRACKER_UPDATED(HttpStatus.OK, "MOODTRACKER200", "분위기 트래커 제목 수정 성공"),
-    MOOD_TRACKER_DELETED(HttpStatus.NO_CONTENT, "MOODTRACKER204", "분위기 트래커 삭제 성공");
+    MOOD_TRACKER_DELETED(HttpStatus.NO_CONTENT, "MOODTRACKER204", "분위기 트래커 삭제 성공"),
+    MOOD_TRACKER_EMAIL_SENT(HttpStatus.OK, "MOODTRACKER200", "분위기 트래커 설문 링크 전송 성공"),
+    MOOD_TRACKER_ANSWER_SUBMIT(HttpStatus.OK, "MOODTRACKER200", "분위기 트래커 설문 답변 제출 성공")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/haru/api/global/config/MailConfig.java
+++ b/src/main/java/com/haru/api/global/config/MailConfig.java
@@ -1,0 +1,35 @@
+package com.haru.api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+@Profile("!test")
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl sender = new JavaMailSenderImpl();
+        sender.setHost(host);
+        sender.setPort(port);
+        sender.setUsername(username);
+        sender.setPassword(password);
+        return sender;
+    }
+}

--- a/src/main/java/com/haru/api/infra/mail/EmailSender.java
+++ b/src/main/java/com/haru/api/infra/mail/EmailSender.java
@@ -1,0 +1,9 @@
+package com.haru.api.infra.mail;
+
+public interface EmailSender {
+    void send(
+            String to,
+            String subject,
+            String content
+    );
+}

--- a/src/main/java/com/haru/api/infra/mail/SmtpEmailSender.java
+++ b/src/main/java/com/haru/api/infra/mail/SmtpEmailSender.java
@@ -1,0 +1,43 @@
+package com.haru.api.infra.mail;
+
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.infra.mail.handler.MailHandler;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public void send(
+            String to,
+            String title,
+            String content
+    ) {
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, false, "UTF-8");
+
+            helper.setTo(to);
+            helper.setSubject(title);
+            helper.setText(content, true); // HTML 지원위해 true 로 설정
+
+            javaMailSender.send(message);
+            log.info("이메일 전송 완료 - 수신자: {}", to);
+
+        } catch (MessagingException e) {
+            log.error("이메일 전송 실패 - 수신자: {}", to, e);
+            throw new MailHandler(ErrorStatus.MAIL_SEND_FAIL);
+        }
+    }
+}
+

--- a/src/main/java/com/haru/api/infra/mail/handler/MailHandler.java
+++ b/src/main/java/com/haru/api/infra/mail/handler/MailHandler.java
@@ -1,0 +1,11 @@
+package com.haru.api.infra.mail.handler;
+
+import com.haru.api.global.apiPayload.code.BaseErrorCode;
+import com.haru.api.global.apiPayload.exception.GeneralException;
+
+public class MailHandler extends GeneralException {
+
+    public MailHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/test/java/com/haru/api/config/MailTestConfig.java
+++ b/src/test/java/com/haru/api/config/MailTestConfig.java
@@ -1,0 +1,17 @@
+package com.haru.api.config;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+@Profile("test")
+public class MailTestConfig {
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return Mockito.mock(JavaMailSender.class);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #59 

## 📝작업 내용
> 작업한 내용을 작성해주세요.
- 팀 분위기 트래커 설문 링크 전송
   - infra에 email sender 구현
   - MoodTrackerMailService로 메일 전송 로직 분리
- 설문 답변 API 구현
   - DTO 에서 받은 설문 질문 타입으로 구분하여 각각 로직에 맞게 처리해줌
   - 필수 질문에 답변을 안할 시 에러 처리

## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기
코드양이 좀 많아진 것 같은데 다음부터는 작게 이슈 나누겠습니다..!

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
