### PR TITLE
feat/#77: ai meeting 안건 요약 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ dependencies {
 
 	// hash
 	implementation 'org.hashids:hashids:1.0.3'
+
+	// apache
+	implementation 'org.apache.pdfbox:pdfbox:2.0.27'
 }
 
 dependencyManagement {

--- a/src/main/java/com/haru/api/domain/meeting/dto/MeetingRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/meeting/dto/MeetingRequestDTO.java
@@ -1,12 +1,16 @@
 package com.haru.api.domain.meeting.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class MeetingRequestDTO {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class createMeetingRequest{
         private Long workspaceId;
         private String title;

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingCommandServiceImpl.java
@@ -13,6 +13,7 @@ import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MeetingHandler;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
+import com.haru.api.infra.api.client.ChatGPTClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
     private final UserRepository userRepository;
     private final WorkspaceRepository workspaceRepository;
     private final MeetingRepository meetingRepository;
+    private final ChatGPTClient chatGPTClient;
 
     @Override
     @Transactional
@@ -41,7 +43,8 @@ public class MeetingCommandServiceImpl implements MeetingCommandService {
                 .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
 
         // agendaFile을 openAi 활용하여 요약 - 미구현
-        String agendaResult = "안건지 요약 - 미구현";
+        String agendaResult = chatGPTClient.summarizePdf(agendaFile)
+                .block();
 
 
         Meeting newMeeting = Meeting.createInitialMeeting(

--- a/src/main/java/com/haru/api/infra/api/client/ChatGPTClient.java
+++ b/src/main/java/com/haru/api/infra/api/client/ChatGPTClient.java
@@ -4,11 +4,20 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.haru.api.infra.api.dto.AIQuestionResponse;
 import com.haru.api.infra.api.dto.OpenAIResponse;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -80,5 +89,65 @@ public class ChatGPTClient {
                         sink.error(new RuntimeException(e));
                     }
                 });
+    }
+
+    public Mono<String> summarizePdf(MultipartFile pdfFile) {
+        try (PDDocument document = PDDocument.load(pdfFile.getInputStream())) {
+            PDFRenderer pdfRenderer = new PDFRenderer(document);
+            int pageCount = document.getNumberOfPages(); // PDF의 전체 페이지 수 가져오기
+
+            // 1. 요청 본문의 content 부분을 담을 리스트 생성
+            List<Map<String, Object>> contentParts = new ArrayList<>();
+
+            // 1-1. 첫 번째 파트로 텍스트 프롬프트 추가
+            contentParts.add(Map.of(
+                    "type", "text",
+                    "text", "이 이미지들은 하나의 연속된 문서입니다. 전체 내용을 종합해서 전체 내용을 종합해서 **반드시 255자 이내의 짧은 문단으로** 한국어로 요약해줘."
+            ));
+
+            // 2. 모든 페이지를 순회하며 이미지로 변환하고 리스트에 추가
+            for (int i = 0; i < pageCount; i++) {
+                BufferedImage bufferedImage = pdfRenderer.renderImageWithDPI(i, 300); // i번째 페이지 렌더링
+
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ImageIO.write(bufferedImage, "png", baos);
+                byte[] imageBytes = baos.toByteArray();
+                String base64Image = Base64.getEncoder().encodeToString(imageBytes);
+
+                // 2-1. 이미지 파트를 리스트에 추가
+                contentParts.add(Map.of(
+                        "type", "image_url",
+                        "image_url", Map.of("url", "data:image/png;base64," + base64Image)
+                ));
+            }
+
+            // 3. 최종 요청 본문 구성
+            List<Map<String, Object>> messages = List.of(
+                    Map.of(
+                            "role", "system",
+                            "content", "너는 이미지에 있는 텍스트를 정확하게 읽고 핵심 내용을 간결하게 요약하는 전문 AI야."
+                    ),
+                    Map.of(
+                            "role", "user",
+                            "content", contentParts // 텍스트 프롬프트와 모든 이미지가 담긴 리스트 사용
+                    )
+            );
+
+            Map<String, Object> requestBody = Map.of(
+                    "model", "gpt-4o",
+                    "messages", messages,
+                    "max_tokens", 300
+            );
+
+            // 4. API 호출
+            return webClient.post()
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(OpenAIResponse.class)
+                    .map(response -> response.getChoices().get(0).getMessage().getContent());
+
+        } catch (IOException e) {
+            return Mono.error(new RuntimeException("파일을 이미지로 변환 중 오류가 발생했습니다.", e));
+        }
     }
 }

--- a/src/main/java/com/haru/api/infra/api/dto/OpenAIResponse.java
+++ b/src/main/java/com/haru/api/infra/api/dto/OpenAIResponse.java
@@ -1,19 +1,23 @@
 package com.haru.api.infra.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenAIResponse {
     private List<Choice> choices;
 
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Choice {
         private Message message;
     }
 
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Message {
         private String role;
         private String content;


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #77 

## 📝작업 내용
> 
- createMeetingRequest 객체 변환 오류 수정
- openApi의 DTO와 JSON 응답의 불일치 방지 (@JsonIgnoreProperties(ignoreUnknown = true) 추가)
- apache 의존성 추가
- MeetingService createMeeting에 ai 요약 메서드 사용

## 🔎코드 설명(스크린샷(선택))
> 코드에 대한 설명을 작성해주세요.

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
