### PR TITLE
feat/#79: 팀 분위기 트래커 리포트 및 제안 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// scheduled
+	implementation 'org.springframework:spring-context-support'
+
 	//Jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/haru/api/HaruApiApplication.java
+++ b/src/main/java/com/haru/api/HaruApiApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 @EnableJpaAuditing
+@EnableScheduling
 public class HaruApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/controller/MoodTrackerController.java
@@ -133,4 +133,20 @@ public class MoodTrackerController {
         return ApiResponse.of(SuccessStatus.MOOD_TRACKER_ANSWER_SUBMIT, null);
     }
 
+    @PostMapping("/{mood-tracker-hashed-Id}/report-test")
+    @Operation(
+            summary = "분위기 트래커 설문 리포트 생성 테스트 API",
+            description = "# 해당 ID의 분위기 트래커 설문 리포트를 즉시 생성합니다."
+    )
+    @Parameters({
+            @Parameter(name = "mood-tracker-hashed-Id", description = "해시된 16자 분위기 트래커 ID (Path Variable)", required = true)
+    })
+    public  ApiResponse<Void> generateMoodTrackerReportTest (
+            @PathVariable("mood-tracker-hashed-Id") String moodTrackerHashedId
+    ) {
+        Long moodTrackerId = hashIdUtil.decode(moodTrackerHashedId);
+        moodTrackerCommandService.generateReportTest(moodTrackerId);
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/MoodTracker.java
@@ -70,4 +70,6 @@ public class MoodTracker extends BaseEntity {
     public void updateTitle(String title) {
         this.title = title;
     }
+
+    public void createReport(String report) { this.report = report; }
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/entity/SurveyQuestion.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/entity/SurveyQuestion.java
@@ -36,6 +36,9 @@ public class SurveyQuestion {
     @Column(name = "is_mandatory", nullable = false)
     private Boolean isMandatory;
 
+    @Column(name = "suggestion", columnDefinition = "TEXT")
+    private String suggestion;
+
     @OneToMany(mappedBy = "surveyQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MultipleChoice> multipleChoiceList = new ArrayList<>();
 
@@ -44,5 +47,9 @@ public class SurveyQuestion {
 
     @OneToMany(mappedBy = "surveyQuestion", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SubjectiveAnswer> subjectiveAnswerList = new ArrayList<>();
+
+    public void createSuggestion(String suggestion) {
+        this.suggestion = suggestion;
+    }
 }
 

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/CheckboxChoiceAnswerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/CheckboxChoiceAnswerRepository.java
@@ -1,9 +1,13 @@
 package com.haru.api.domain.moodTracker.repository;
 
 import com.haru.api.domain.moodTracker.entity.CheckboxChoiceAnswer;
+import com.haru.api.domain.moodTracker.entity.SurveyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CheckboxChoiceAnswerRepository extends JpaRepository<CheckboxChoiceAnswer, Long> {
+    List<CheckboxChoiceAnswer> findAllByCheckboxChoice_SurveyQuestionIn(List<SurveyQuestion> questions);
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MultipleChoiceAnswerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MultipleChoiceAnswerRepository.java
@@ -1,9 +1,13 @@
 package com.haru.api.domain.moodTracker.repository;
 
 import com.haru.api.domain.moodTracker.entity.MultipleChoiceAnswer;
+import com.haru.api.domain.moodTracker.entity.SurveyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MultipleChoiceAnswerRepository extends JpaRepository<MultipleChoiceAnswer, Long> {
+    List<MultipleChoiceAnswer> findAllByMultipleChoice_SurveyQuestionIn(List<SurveyQuestion> questions);
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/SubjectiveAnswerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/SubjectiveAnswerRepository.java
@@ -1,9 +1,13 @@
 package com.haru.api.domain.moodTracker.repository;
 
 import com.haru.api.domain.moodTracker.entity.SubjectiveAnswer;
+import com.haru.api.domain.moodTracker.entity.SurveyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SubjectiveAnswerRepository extends JpaRepository<SubjectiveAnswer, Long> {
+    List<SubjectiveAnswer> findAllBySurveyQuestionIn(List<SurveyQuestion> questions);
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandService.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerCommandService.java
@@ -25,4 +25,7 @@ public interface MoodTrackerCommandService {
             Long moodTrackerId,
             MoodTrackerRequestDTO.SurveyAnswerList request
     );
+    void generateReportTest(
+            Long moodTrackerId
+    );
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportService.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportService.java
@@ -1,0 +1,5 @@
+package com.haru.api.domain.moodTracker.service;
+
+public interface MoodTrackerReportService {
+    void generateReport(Long moodTrackerId);
+}

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerReportServiceImpl.java
@@ -1,0 +1,150 @@
+package com.haru.api.domain.moodTracker.service;
+
+import com.haru.api.infra.api.dto.SurveyReportResponse;
+import com.haru.api.domain.moodTracker.entity.*;
+import com.haru.api.domain.moodTracker.repository.*;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MoodTrackerHandler;
+import com.haru.api.infra.api.client.ChatGPTClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MoodTrackerReportServiceImpl implements MoodTrackerReportService {
+
+    private final ChatGPTClient chatGPTClient;
+    private final MoodTrackerRepository moodTrackerRepository;
+    private final SurveyQuestionRepository surveyQuestionRepository;
+    private final SubjectiveAnswerRepository subjectiveAnswerRepository;
+    private final MultipleChoiceAnswerRepository multipleChoiceAnswerRepository;
+    private final CheckboxChoiceAnswerRepository checkboxChoiceAnswerRepository;
+
+    @Async
+    public void generateReport(Long moodTrackerId) {
+        MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
+                .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
+
+        // 전체 질문 조회 (ID 기준 정렬 보장)
+        List<SurveyQuestion> questions = surveyQuestionRepository.findAllByMoodTrackerId(moodTrackerId);
+
+        // 응답 수집 (질문 기반 조회)
+        List<SubjectiveAnswer> subjectiveAnswerList = subjectiveAnswerRepository.findAllBySurveyQuestionIn(questions);
+        List<MultipleChoiceAnswer> multipleAnswerList = multipleChoiceAnswerRepository.findAllByMultipleChoice_SurveyQuestionIn(questions);
+        List<CheckboxChoiceAnswer> checkboxAnswerList = checkboxChoiceAnswerRepository.findAllByCheckboxChoice_SurveyQuestionIn(questions);
+
+        // 통계 생성용 맵
+        Map<Long, List<SubjectiveAnswer>> subjectiveMap = subjectiveAnswerList.stream()
+                .collect(Collectors.groupingBy(ans -> ans.getSurveyQuestion().getId()));
+
+        Map<Long, Map<String, Long>> multipleStats = new HashMap<>();
+        for (MultipleChoiceAnswer multipleChoiceAnswer : multipleAnswerList) {
+            Long qid = multipleChoiceAnswer.getMultipleChoice().getSurveyQuestion().getId();
+            String content = multipleChoiceAnswer.getMultipleChoice().getContent();
+            multipleStats.computeIfAbsent(qid, k -> new LinkedHashMap<>());
+            multipleStats.get(qid).merge(content, 1L, Long::sum);
+        }
+
+        Map<Long, Map<String, Long>> checkboxStats = new HashMap<>();
+        for (CheckboxChoiceAnswer ans : checkboxAnswerList) {
+            Long qid = ans.getCheckboxChoice().getSurveyQuestion().getId();
+            String content = ans.getCheckboxChoice().getContent();
+            checkboxStats.computeIfAbsent(qid, k -> new LinkedHashMap<>());
+            checkboxStats.get(qid).merge(content, 1L, Long::sum);
+        }
+
+        // 프롬프트 생성
+        String prompt = buildPrompt(foundMoodTracker.getTitle(), questions, subjectiveMap, multipleStats, checkboxStats);
+
+        try {
+            // GPT 호출 + 파싱
+            SurveyReportResponse response = chatGPTClient.getMoodTrackerReport(prompt).block();
+            log.debug("[GPT 파싱 성공]\n{}\n{}", response.getReport(), response.getSuggestionsByQuestionId());
+
+            // 전체 리포트 저장
+            foundMoodTracker.createReport(response.getReport());
+
+            // 제안 저장
+            Map<Long, String> suggestionMap = response.getSuggestionsByQuestionId();
+            for (SurveyQuestion question : questions) {
+                Long qid = question.getId();
+                if (suggestionMap.containsKey(qid)) {
+                    String suggestion = suggestionMap.get(qid);
+                    if (suggestion != null && !suggestion.isBlank()) {
+                        log.debug("[Suggestion 저장]\n{}: {}", qid, suggestion);
+                        question.createSuggestion(suggestion);
+                    }
+                }
+            }
+
+        } catch (IllegalStateException e) {
+            log.warn("이미 suggestion이 생성된 질문이 존재합니다. 일부 항목은 건너뜁니다.");
+        } catch (Exception e) {
+            throw new RuntimeException("GPT 응답 파싱 실패", e);
+        }
+
+        moodTrackerRepository.save(foundMoodTracker);
+    }
+
+    private String buildPrompt(String title,
+                               List<SurveyQuestion> questions,
+                               Map<Long, List<SubjectiveAnswer>> subjectiveMap,
+                               Map<Long, Map<String, Long>> multipleStats,
+                               Map<Long, Map<String, Long>> checkboxStats) {
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("아래는 설문 문항입니다. 각 문항에는 객관식, 체크박스, 주관식 응답이 섞여 있으며, 무조건 활용하세요.\n");
+
+        sb.append("다음은 '").append(title).append("' 설문에 대한 객관식 답변 통계 및 주관식 답변입니다.\n\n");
+
+        for (SurveyQuestion question : questions) {
+            Long qid = question.getId();
+            sb.append("질문 id: ").append(qid).append("\n");
+            sb.append("질문 내용: ").append(question.getTitle()).append("\n");
+
+            switch (question.getType()) {
+                case SUBJECTIVE -> {
+                    List<SubjectiveAnswer> answers = subjectiveMap.getOrDefault(qid, List.of());
+                    if (answers.isEmpty()) {
+                        sb.append("- (응답 없음)\n");
+                    } else {
+                        for (SubjectiveAnswer ans : answers) {
+                            sb.append("- ").append(ans.getAnswer()).append("\n");
+                        }
+                    }
+                }
+
+                case MULTIPLE_CHOICE -> {
+                    Map<String, Long> stat = multipleStats.getOrDefault(qid, Map.of());
+                    List<MultipleChoice> choices = question.getMultipleChoiceList();
+                    for (MultipleChoice choice : choices) {
+                        String content = choice.getContent();
+                        Long count = stat.getOrDefault(content, 0L);
+                        sb.append("- ").append(content).append(": ").append(count).append("명\n");
+                    }
+                }
+
+                case CHECKBOX_CHOICE -> {
+                    Map<String, Long> stat = checkboxStats.getOrDefault(qid, Map.of());
+                    List<CheckboxChoice> choices = question.getCheckboxChoiceList();
+                    for (CheckboxChoice choice : choices) {
+                        String content = choice.getContent();
+                        Long count = stat.getOrDefault(content, 0L);
+                        sb.append("- ").append(content).append(": ").append(count).append("명\n");
+                    }
+                }
+            }
+
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/haru/api/infra/api/client/ChatGPTClient.java
+++ b/src/main/java/com/haru/api/infra/api/client/ChatGPTClient.java
@@ -2,8 +2,10 @@ package com.haru.api.infra.api.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.haru.api.infra.api.dto.SurveyReportResponse;
 import com.haru.api.infra.api.dto.AIQuestionResponse;
 import com.haru.api.infra.api.dto.OpenAIResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -12,6 +14,7 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
 public class ChatGPTClient {
 
@@ -78,6 +81,104 @@ public class ChatGPTClient {
                         sink.next(new ObjectMapper().readValue(content, AIQuestionResponse.class)); // 최종 질문 DTO로 변환
                     } catch (JsonProcessingException e) {
                         sink.error(new RuntimeException(e));
+                    }
+                });
+    }
+
+    public String getMoodTrackerReportRaw(String userMessageContent) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("너는 팀 심리 및 조직 문화 분석가야. 아래의 설문 응답을 통해 전체 설문을 종합한 마크다운 형식의 분석 리포트를 작성하고, 설문 질문 별로 개선 제안을 각 1개씩 제시해줘.\n\n");
+
+        sb.append("💡 최종 리포트 형식은 다음과 같아야 합니다:\n");
+        sb.append("1. {title} + 리포트\n");
+        sb.append("   - 대상과 목적, 분석 방식 등을 간단히 정리\n");
+        sb.append("2. 주요 인사이트 요약 (AI가 뽑은 핵심 요약)\n");
+        sb.append("   - 사용자의 응답 중 반복되거나 주목할 만한 인사이트를 요약\n");
+        sb.append("   - 전체 응답자의 몇 %가 어떤 패턴을 보였는지도 서술\n");
+        sb.append("3. 자유 응답 기반 주요 키워드 정리 (많이 등장한 순서대로)\n");
+        sb.append("   - 예: 잦힌 (37건), 말은 덜 불분명 (29건) 등\n\n");
+
+        sb.append("응답은 반드시 다음 JSON 형식으로 해줘. 형식만 따르고, 값은 생성한 값을 넣어줘야해. 질문에 대한 제안은 입력받은 질문 Id와 해당 질문에 매칭되는 제안 내용을 넣어줘. : \n");
+        sb.append("{\n");
+        sb.append("  \"report\": \"전체 리포트 마크다운 텍스트\",\n");
+        sb.append("  \"suggestionsByQuestionId\": {\n");
+        sb.append("    \"1\": \"질문 1에 대한 제안 내용\",\n");
+        sb.append("    \"2\": \"질문 2에 대한 제안 내용\"\n");
+        sb.append("  }\n");
+        sb.append("}");
+
+        List<Map<String, String>> messages = List.of(
+                Map.of("role", "system", "content", sb.toString()),
+                Map.of("role", "user", "content", userMessageContent)
+        );
+
+        log.debug("[GPT 요청 messages - RAW용] \n{}", messages);
+
+        return webClient.post()
+                .bodyValue(Map.of(
+                        "model", "gpt-4o",
+                        "messages", messages,
+                        "temperature", 0.5
+                ))
+                .retrieve()
+                .bodyToMono(OpenAIResponse.class)
+                .map(response -> {
+                    String content = response.getChoices().get(0).getMessage().getContent();
+                    log.debug("[GPT 응답 메시지 content - RAW] \n{}", content);
+                    return content;
+                })
+                .block(); // 개발 중 테스트 편의를 위해 동기 블록 처리
+    }
+
+    public Mono<SurveyReportResponse> getMoodTrackerReport(String userMessageContent) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("너는 팀 심리 및 조직 문화 분석가야. 아래의 설문 응답을 통해 전체 설문을 종합한 마크다운 형식의 분석 리포트를 작성하고, 설문 질문 별로 개선 제안을 각 1개씩 제시해줘.\n\n");
+
+        sb.append("💡 최종 리포트 형식은 다음과 같아야 합니다:\n");
+        sb.append("1. {title} + 리포트\n");
+        sb.append("   - 대상과 목적, 분석 방식 등을 간단히 정리\n");
+        sb.append("2. 주요 인사이트 요약 (AI가 뽑은 핵심 요약)\n");
+        sb.append("   - 사용자의 응답 중 반복되거나 주목할 만한 인사이트를 요약\n");
+        sb.append("   - 전체 응답자의 몇 %가 어떤 패턴을 보였는지도 서술\n");
+        sb.append("3. 자유 응답 기반 주요 키워드 정리 (많이 등장한 순서대로)\n");
+        sb.append("   - 예: 잦힌 (37건), 말은 덜 불분명 (29건) 등\n\n");
+
+        sb.append("응답은 반드시 다음 JSON 형식으로 해줘. 형식만 따르고, 값은 생성한 값을 넣어줘야해. 질문에 대한 제안은 입력받은 질문 Id와 해당 질문에 매칭되는 제안 내용을 넣어줘. : \n");
+        sb.append("{\n");
+        sb.append("  \"report\": \"전체 리포트 마크다운 텍스트\",\n");
+        sb.append("  \"suggestionsByQuestionId\": {\n");
+        sb.append("    \"1\": \"질문 1에 대한 제안 내용\",\n");
+        sb.append("    \"2\": \"질문 2에 대한 제안 내용\"\n");
+        sb.append("  }\n");
+        sb.append("}");
+
+        List<Map<String, String>> messages = List.of(
+                Map.of("role", "system", "content", sb.toString()),
+                Map.of("role", "user", "content", userMessageContent)
+        );
+
+        return webClient.post()
+                .bodyValue(Map.of(
+                        "model", "gpt-4o",
+                        "messages", messages,
+                        "temperature", 0.5
+                ))
+                .retrieve()
+                .onStatus(status -> status.isError(), clientResponse ->
+                        clientResponse.bodyToMono(String.class)
+                                .doOnNext(errorBody -> log.error("[GPT 응답 에러 발생] 상태코드: {}, 응답 바디: \n{}",
+                                        clientResponse.statusCode(), errorBody))
+                                .flatMap(errorBody ->
+                                        Mono.error(new RuntimeException("GPT 호출 실패: " + errorBody)))
+                )
+                .bodyToMono(OpenAIResponse.class)
+                .doOnNext(response -> log.debug("[GPT 원 응답 JSON] \n{}", response))
+                .handle((response, sink) -> {
+                    String content = response.getChoices().get(0).getMessage().getContent();
+                    try {
+                        sink.next(new ObjectMapper().readValue(content, SurveyReportResponse.class));
+                    } catch (JsonProcessingException e) {
+                        sink.error(new RuntimeException("GPT 응답 파싱 실패: " + content, e));
                     }
                 });
     }

--- a/src/main/java/com/haru/api/infra/api/controller/APIController.java
+++ b/src/main/java/com/haru/api/infra/api/controller/APIController.java
@@ -2,6 +2,7 @@ package com.haru.api.infra.api.controller;
 
 import com.haru.api.infra.api.client.ChatGPTClient;
 import com.haru.api.infra.api.dto.AIQuestionRequest;
+import com.haru.api.infra.api.dto.SurveyReportRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,10 +17,18 @@ public class APIController {
     private final ChatGPTClient chatGPTClient;
 
     /**
-     * ChatGPT APi 테스트용 컨트롤러
+     * ChatGPT AI 회의 진행 매니져 질문 생성 API 테스트
      */
-    @PostMapping
-    public String getChatGPTResponse(@RequestBody AIQuestionRequest request) {
+    @PostMapping("ai-question")
+    public String getMeetingAIQuestionChatGPTResponse(@RequestBody AIQuestionRequest request) {
         return chatGPTClient.getAIQuestionsRaw(request.getMeetingContent());
+    }
+
+    /**
+     * ChatGPT 팀 분위기 트래커 설문 리포트 생성 API 테스트
+     */
+    @PostMapping("report")
+    public String getMoodTrackerReportChatGPTResponse(@RequestBody SurveyReportRequest request) {
+        return chatGPTClient.getMoodTrackerReportRaw(request.getMoodTrackerContent());
     }
 }

--- a/src/main/java/com/haru/api/infra/api/dto/OpenAIResponse.java
+++ b/src/main/java/com/haru/api/infra/api/dto/OpenAIResponse.java
@@ -1,19 +1,23 @@
 package com.haru.api.infra.api.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenAIResponse {
     private List<Choice> choices;
 
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Choice {
         private Message message;
     }
 
     @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Message {
         private String role;
         private String content;

--- a/src/main/java/com/haru/api/infra/api/dto/SurveyReportRequest.java
+++ b/src/main/java/com/haru/api/infra/api/dto/SurveyReportRequest.java
@@ -1,0 +1,8 @@
+package com.haru.api.infra.api.dto;
+
+import lombok.Data;
+
+@Data
+public class SurveyReportRequest {
+    private String moodTrackerContent;
+}

--- a/src/main/java/com/haru/api/infra/api/dto/SurveyReportResponse.java
+++ b/src/main/java/com/haru/api/infra/api/dto/SurveyReportResponse.java
@@ -1,0 +1,14 @@
+package com.haru.api.infra.api.dto;
+
+import lombok.*;
+
+import java.util.Map;
+
+@Data
+public class SurveyReportResponse {
+    // 전체 리포트 내용
+    private String report;
+
+    // 각 질문 ID별 suggestion
+    private Map<Long, String> suggestionsByQuestionId;
+}

--- a/src/main/java/com/haru/api/infra/redis/RedisReportConsumer.java
+++ b/src/main/java/com/haru/api/infra/redis/RedisReportConsumer.java
@@ -1,0 +1,42 @@
+package com.haru.api.infra.redis;
+
+import com.haru.api.domain.moodTracker.service.MoodTrackerReportService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisReportConsumer {
+
+    private final StringRedisTemplate redisTemplate;
+    private final MoodTrackerReportService moodTrackerReportService;
+
+    private static final String QUEUE_KEY = "MOOD_TRACKER_REPORT_GPT_QUEUE";
+    private static final long BATCH_SIZE = 20;
+
+    @Scheduled(cron = "0 0/30 * * * *") // 매시 0분, 30분 실행
+    public void pollQueueEvery30Minutes() {
+        long now = Instant.now().getEpochSecond();
+
+        Set<String> dueIds = redisTemplate.opsForZSet()
+                .rangeByScore(QUEUE_KEY, 0, now, 0, BATCH_SIZE);
+
+        if (dueIds == null || dueIds.isEmpty()) return;
+
+        for (String moodTrackerId : dueIds) {
+            try {
+                moodTrackerReportService.generateReport(Long.parseLong(moodTrackerId));
+                redisTemplate.opsForZSet().remove(QUEUE_KEY, moodTrackerId);
+            } catch (Exception e) {
+                log.error("GPT 리포트 생성 실패: {}", moodTrackerId, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/haru/api/infra/redis/RedisReportProducer.java
+++ b/src/main/java/com/haru/api/infra/redis/RedisReportProducer.java
@@ -1,0 +1,21 @@
+package com.haru.api.infra.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class RedisReportProducer {
+
+    private final StringRedisTemplate redisTemplate;
+    private static final String QUEUE_KEY = "MOOD_TRACKER_REPORT_GPT_QUEUE";
+
+    public void scheduleReport(Long moodTrackerId, LocalDateTime dueDate) {
+        long score = dueDate.atZone(ZoneId.systemDefault()).toEpochSecond();
+        redisTemplate.opsForZSet().add(QUEUE_KEY, String.valueOf(moodTrackerId), score);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,5 +15,6 @@ spring:
 
 logging:
   level:
+    root: INFO
     org.springframework.web: DEBUG
     org.springframework.web.client.DefaultRestClient: OFF


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #79 

## 📝작업 내용
> 작업한 내용을 작성해주세요.
- ChatGPTClient에 리포트 생성 메소드 추가
- MoodTrackerReportService에 리포트 생성 메소드 작성하여서 응답 통계 값을 ChatGPTClient에 요청하여 리포트와 제안 값 응답 파싱하여 저장해줌
- Redis Queue를 활용하여 큐에 넣어두고(produce) 스케쥴러를 통해 consume 할 수 있도록 infra.redis에 RedisReportConsumer와 RedisReportProducer 작성
- 위를 즉시 테스트할 수 있도록 APIController와 MoodTrackerControllter에 API 작성

## 🔎스크린샷
> 코드에 대한 설명을 작성해주세요.
- mood_trackers에 생성된 report
<img width="945" height="337" alt="image" src="https://github.com/user-attachments/assets/9033af0b-9f13-49ee-b9f6-a7c6325c238b" />

- survey_questions에 생성된 suggestion
<img width="934" height="134" alt="image" src="https://github.com/user-attachments/assets/5e9417e3-5655-494c-a1a4-4d67d6b58f44" />

## 💬고민사항 및 리뷰 요구사항 (Optional)
> 고민사항 및 의견 받고 싶은 부분 있으면 적어두기

## 비고 (Optional)
> 참고했던 링크 등 참고 사항을 적어주세요. 코드 리뷰하는 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다.
