### PR TITLE
feat/#93: 초대 메일 발송 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -94,4 +94,17 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(documentList);
     }
 
+    @Operation(summary = "워크스페이스 초대 메일 발송", description =
+            "# 워크스페이스 초대 메일 발송 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    )
+    @PostMapping("/invite") ApiResponse<Void> sendInviteEmail(
+            @RequestBody WorkspaceRequestDTO.WorkspaceInviteEmailRequest request
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        workspaceCommandService.sendInviteEmail(userId, request);
+
+        return ApiResponse.onSuccess(null);
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceRequestDTO.java
@@ -1,8 +1,10 @@
 package com.haru.api.domain.workspace.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -21,5 +23,14 @@ public class WorkspaceRequestDTO {
     public static class WorkspaceUpdateRequest {
         @NotBlank(message = "수정하고자 하는 제목은 빈 값일 수 없습니다.")
         private String title;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WorkspaceInviteEmailRequest {
+        private Long workspaceId;
+        private List<String> emails;
     }
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -10,4 +10,6 @@ public interface WorkspaceCommandService {
     WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceid, WorkspaceRequestDTO.WorkspaceUpdateRequest request);
 
     void acceptInvite(String code);
+
+    void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
@@ -17,9 +17,14 @@ import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import com.haru.api.global.apiPayload.exception.handler.UserWorkspaceHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceInvitationHandler;
+import com.haru.api.infra.mail.EmailSender;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +34,11 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
     private final WorkspaceRepository workspaceRepository;
     private final UserWorkspaceRepository userWorkspaceRepository;
     private final WorkspaceInvitationRepository workspaceInvitationRepository;
+
+    private final EmailSender emailSender;
+
+    @Value("${invite-url}")
+    private String inviteBaseUrl;
 
     @Transactional
     @Override
@@ -115,9 +125,62 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
                 .build());
     }
 
-    private Long codeToInvitationId(String code) {
-        return 1l;
+    @Transactional
+    @Override
+    public void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request) {
+        Long workspaceId = request.getWorkspaceId();
+        List<String> emails = request.getEmails();
+
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+
+        userWorkspaceRepository.findByUserAndWorkspace(foundUser, foundWorkspace)
+                .orElseThrow(() -> new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND));
+
+        // 이메일마다 invitation 생성하여 저장, 초대 수락 토큰 생성, 초대 이메일 발송
+        for(String email: emails) {
+            String token = UUID.randomUUID().toString();
+
+            WorkspaceInvitation workspaceInvitation = WorkspaceInvitation.builder()
+                    .email(email)
+                    .workspace(foundWorkspace)
+                    .token(token)
+                    .isAccepted(false)
+                    .build();
+            workspaceInvitationRepository.save(workspaceInvitation);
+
+            String invitationLink = inviteBaseUrl + "?token=" + token;
+
+            String subject = String.format("[%s] 에서 [%s] 님이 당신을 초대했어요!", foundWorkspace.getTitle(), foundUser.getName());
+            String content = generateInvitationEmailContentHtml(email, foundUser.getName(), foundWorkspace.getTitle(), invitationLink);
+
+            emailSender.send(email, subject, content);
+        }
+
     }
 
+    private String generateInvitationEmailContentHtml(String invitedEmail, String inviterName, String workspaceName, String invitationLink) {
+        return String.format(
+                "<html>" +
+                        "<head></head>" +
+                        "<body>" +
+                        "  <p>안녕하세요, %s님,</p>" +
+                        "  <p>%s님께서 <b>%s</b> 워크스페이스에 당신을 초대했습니다.</p>" +
+                        "  <p>아래 버튼을 클릭하여 워크스페이스에 합류해 주세요!</p>" +
+                        "  <p style=\"margin-top: 20px;\">" + // 버튼 스타일
+                        "    <a href=\"%s\" " +
+                        "       style=\"display: inline-block; padding: 10px 20px; font-size: 16px; color: white; background-color: #007bff; text-decoration: none; border-radius: 5px;\">" +
+                        "      초대 수락하기" +
+                        "    </a>" +
+                        "  </p>" +
+                        "  <p style=\"margin-top: 30px;\">감사합니다.<br/><b>HaRu 팀 드림</b></p>" +
+                        "</body>" +
+                        "</html>",
+                invitedEmail, inviterName, workspaceName, invitationLink
+        );
+    }
 
 }

--- a/src/main/java/com/haru/api/domain/workspaceInvitation/entity/WorkspaceInvitation.java
+++ b/src/main/java/com/haru/api/domain/workspaceInvitation/entity/WorkspaceInvitation.java
@@ -25,8 +25,10 @@ public class WorkspaceInvitation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id")
-    Workspace workspace;
+    private Workspace workspace;
 
-    // 초대코드는 pk를 사용해서 해싱
+    private String token;
+
+    private boolean isAccepted = false;
 
 }

--- a/src/main/java/com/haru/api/global/config/MailConfig.java
+++ b/src/main/java/com/haru/api/global/config/MailConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.Properties;
+
 @Configuration
 @Profile("!test")
 public class MailConfig {
@@ -23,6 +25,15 @@ public class MailConfig {
     @Value("${spring.mail.password}")
     private String password;
 
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean startTlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required:false}")
+    private boolean startTlsRequired;
+
     @Bean
     public JavaMailSender javaMailSender() {
         JavaMailSenderImpl sender = new JavaMailSenderImpl();
@@ -30,6 +41,15 @@ public class MailConfig {
         sender.setPort(port);
         sender.setUsername(username);
         sender.setPassword(password);
+
+        Properties properties = sender.getJavaMailProperties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", startTlsEnable);
+        properties.put("mail.smtp.starttls.required", startTlsRequired);
+
+        sender.setJavaMailProperties(properties);
+        sender.setDefaultEncoding("UTF-8");
+
         return sender;
     }
 }

--- a/src/main/java/com/haru/api/infra/mail/SmtpEmailSender.java
+++ b/src/main/java/com/haru/api/infra/mail/SmtpEmailSender.java
@@ -6,6 +6,7 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,9 @@ import org.springframework.stereotype.Component;
 public class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String from;
 
     @Override
     public void send(
@@ -30,6 +34,7 @@ public class SmtpEmailSender implements EmailSender {
             helper.setTo(to);
             helper.setSubject(title);
             helper.setText(content, true); // HTML 지원위해 true 로 설정
+            helper.setFrom(from); // 보내는 계정
 
             javaMailSender.send(message);
             log.info("이메일 전송 완료 - 수신자: {}", to);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,13 +1,3 @@
-cloud:
-  aws:
-    s3:
-      bucket: haru-it-bucket
-    region:
-      static: ap-northeast-2
-    credentials:
-      accessKey: dummy-key
-      secretKey: dummy-secret
-
 spring:
   datasource:
     url: jdbc:h2:mem:testdb
@@ -17,6 +7,7 @@ spring:
   mail:
     host: dummy
     port: 1025
+    username: dumb
 
 hashid:
   salt: dummy-salt
@@ -33,3 +24,15 @@ api:
 
   openai:
     api-key: test_api_key
+
+cloud:
+  aws:
+    s3:
+      bucket: haru-it-bucket
+    region:
+      static: ap-northeast-2
+    credentials:
+      accessKey: dummy-key
+      secretKey: dummy-secret
+
+invite-url: invite-url


### PR DESCRIPTION
## #️⃣연관된 이슈
> #93

## 📝작업 내용
> 초대 메일 발송 기능 구현

## 🔎코드 설명(스크린샷(선택))
- dto로 workspaceId, emails를 받아옴
- 각 이메일마다 workspace invitation를 생성하여 저장하고, 초대 링크에 token을 쿼리스트링으로 추가해서 버튼을 누르면 해당 링크로 GET 요청이 보내져 초대 수락하도록 구현
- SmtpEmailSender에서 오류가 발생하여 helper.setFrom(from) 추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X