### PR TITLE
fix/#109: ObjectMapper추가시 발생하는 오류 해결 및 일반 회원가입 API 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/haru/api/domain/user/converter/UserConverter.java
@@ -11,6 +11,7 @@ public class UserConverter {
                 .email(request.getEmail())
                 .name(request.getName())
                 .password(password)
+                .marketingAgreed(request.isMarketingAgreed())
                 .status(Status.ACTIVE)
                 .build();
     }

--- a/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
@@ -1,6 +1,7 @@
 package com.haru.api.domain.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 public class UserRequestDTO {
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class SignUpRequest {
         @NotBlank(message = "이메일은 빈값일 수 없습니다.")
         private String email;
@@ -17,6 +20,7 @@ public class UserRequestDTO {
         private String password;
         @NotBlank(message = "이름은 빈값일 수 없습니다.")
         private String name;
+        private boolean marketingAgreed;
     }
 
     @Getter
@@ -32,6 +36,8 @@ public class UserRequestDTO {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class UserInfoUpdateRequest {
         @NotBlank(message = "이름은 빈 값일 수 없습니다.")
         private String name;

--- a/src/main/java/com/haru/api/domain/user/entity/User.java
+++ b/src/main/java/com/haru/api/domain/user/entity/User.java
@@ -32,6 +32,8 @@ public class User extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String password;
 
+    private boolean marketingAgreed;
+
     @Enumerated(EnumType.STRING)
     @Column
     private Status status;

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -42,8 +42,14 @@ public class UserCommandServiceImpl implements UserCommandService{
     @Override
     public void signUp(UserRequestDTO.SignUpRequest request) {
         String password = passwordEncoder.encode(request.getPassword());
-        User user = UserConverter.toUsers(request, password);
-        userRepository.save(user);
+        // 이메일 중복 확인
+        User foundUser = userRepository.findByEmail(request.getEmail()).orElse(null);
+        if (foundUser != null) {
+            throw new MemberHandler(ErrorStatus.MEMBER_ALREADY_EXISTS);
+        } else {
+            User user = UserConverter.toUsers(request, password);
+            userRepository.save(user);
+        }
     }
 
     @Override

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceRequestDTO.java
@@ -1,8 +1,10 @@
 package com.haru.api.domain.workspace.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
@@ -10,6 +12,8 @@ public class WorkspaceRequestDTO {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class WorkspaceCreateRequest {
         @NotBlank(message = "워크스페이스 제목은 빈 값일 수 없습니다.")
         private String name;
@@ -18,6 +22,8 @@ public class WorkspaceRequestDTO {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class WorkspaceUpdateRequest {
         @NotBlank(message = "수정하고자 하는 제목은 빈 값일 수 없습니다.")
         private String title;

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     REFRESH_TOKEN_NOT_EQUAL(HttpStatus.BAD_REQUEST, "MEMBER4002", "리프레시 토큰이 일치하지 않습니다."),
     MEMBER_NO_AUTHORITY(HttpStatus.FORBIDDEN, "MEMBER4003", "수정 및 삭제할 권한이 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 존재하는 회원입니다."),
 
     // Workspace 관련 에러
     WORKSPACE_NOT_FOUND(HttpStatus.BAD_REQUEST,"WORKSPACE4001", "워크스페이스가 없습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> #109

## 📝작업 내용
> 일반 회원가입 API 수정사항: marketingAgreed항목 Request Body에 추가 및 이메일 중복 검사
> ObjectMapper관련 발생 오류 DTO에 @AllArgsConstructor와 @NoArgsConstructor추가하여 해결

## 🔎코드 설명(스크린샷(선택))
> 일반 회원가입 API 수정사항: UserCommandServiceImpl의 signUp메소드 수정
> ObjectMapper관련 발생 오류 DTO에 @AllArgsConstructor와 @NoArgsConstructor추가하여 해결

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x