### PR TITLE
feat/#41 workspace 초대 수락 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/converter/UserDocumentLastOpenedConverter.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/converter/UserDocumentLastOpenedConverter.java
@@ -1,0 +1,44 @@
+package com.haru.api.domain.lastOpened.converter;
+
+import com.haru.api.domain.lastOpened.entity.UserDocumentId;
+import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+import com.haru.api.domain.meeting.entity.Meeting;
+import com.haru.api.domain.moodTracker.entity.MoodTracker;
+import com.haru.api.domain.snsEvent.entity.SnsEvent;
+import com.haru.api.domain.user.entity.User;
+
+public class UserDocumentLastOpenedConverter {
+    public static UserDocumentLastOpened toUserDocumentLastOpened(Meeting meeting, User user) {
+
+        UserDocumentId userDocumentId = new UserDocumentId(user.getId(), meeting.getId(), DocumentType.AI_MEETING_MANAGER);
+
+        return UserDocumentLastOpened.builder()
+                .id(userDocumentId)
+                .user(user)
+                .lastOpened(null)
+                .build();
+    }
+
+    public static UserDocumentLastOpened toUserDocumentLastOpened(SnsEvent snsEvent, User user) {
+
+        UserDocumentId userDocumentId = new UserDocumentId(user.getId(), snsEvent.getId(), DocumentType.SNS_EVENT_ASSISTANT);
+
+        return UserDocumentLastOpened.builder()
+                .id(userDocumentId)
+                .user(user)
+                .lastOpened(null)
+                .build();
+    }
+
+    public static UserDocumentLastOpened toUserDocumentLastOpened(MoodTracker moodTracker, User user) {
+
+        UserDocumentId userDocumentId = new UserDocumentId(user.getId(), moodTracker.getId(), DocumentType.TEAM_MOOD_TRACKER);
+
+        return UserDocumentLastOpened.builder()
+                .id(userDocumentId)
+                .user(user)
+                .lastOpened(null)
+                .build();
+    }
+}

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
@@ -1,7 +1,10 @@
 package com.haru.api.domain.lastOpened.entity;
 
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
@@ -17,9 +20,15 @@ public class UserDocumentId implements Serializable {
     @Column(name = "document_id")
     private Long documentId;
 
-    public UserDocumentId(Long userId, Long documentId) {
+    @Column(name = "document_type")
+    @Enumerated(EnumType.STRING)
+    private DocumentType documentType;
+
+
+    public UserDocumentId(Long userId, Long documentId, DocumentType documentType) {
         this.userId = userId;
         this.documentId = documentId;
+        this.documentType = documentType;
     }
 
     @Override

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
@@ -22,20 +22,13 @@ public class UserDocumentLastOpened {
     @EmbeddedId
     private UserDocumentId id;
 
-    @Column(name = "document_id", nullable = false, insertable = false, updatable = false)
-    private Long documentId;
-
     @MapsId("userId")
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false,
         foreignKey = @ForeignKey(name = "fk_user_document_user"))
     private User user;
 
-    @Column(name = "last_opened", nullable = false)
+    @Column(name = "last_opened")
     private LocalDateTime lastOpened;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "document_type", length = 20, nullable = false)
-    private DocumentType documentType;
 
 }

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -20,7 +20,7 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened  udlo " +
-            "JOIN Meeting mt ON udlo.documentId = mt.id " +
+            "JOIN Meeting mt ON udlo.id.documentId = mt.id " +
             "WHERE udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
             "AND mt.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -15,14 +15,16 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findByWorkspaceOrderByUpdatedAtDesc(Workspace workspace);
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
-            "udlo.documentId, " +
+            "udlo.id.documentId, " +
             "mt.title, " +
-            "udlo.documentType, " +
+            "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN Meeting mt ON udlo.documentId = mt.id " +
-            "WHERE udlo.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
+            "WHERE udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
             "AND mt.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);
+
+    List<Meeting> findAllByWorkspaceId(Long workspaceId);
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -14,13 +14,13 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
     List<MoodTracker> findAllByWorkspaceId(Long workspaceId);
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
-            "udlo.documentId, " +
+            "udlo.id.documentId, " +
             "mt.title, " +
-            "udlo.documentType, " +
+            "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN MoodTracker mt ON udlo.documentId = mt.id " +
-            "WHERE udlo.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
+            "WHERE udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
             "AND mt.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -19,7 +19,7 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened  udlo " +
-            "JOIN MoodTracker mt ON udlo.documentId = mt.id " +
+            "JOIN MoodTracker mt ON udlo.id.documentId = mt.id " +
             "WHERE udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
             "AND mt.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -13,14 +13,16 @@ import java.util.List;
 public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
-            "udlo.documentId, " +
+            "udlo.id.documentId, " +
             "se.title, " +
-            "udlo.documentType, " +
+            "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN SnsEvent se ON udlo.documentId = se.id " +
-            "WHERE udlo.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
+            "WHERE udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
             "AND se.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);
+
+    List<SnsEvent> findAllByWorkspaceId(Long workspaceId);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -18,7 +18,7 @@ public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened  udlo " +
-            "JOIN SnsEvent se ON udlo.documentId = se.id " +
+            "JOIN SnsEvent se ON udlo.id.documentId = se.id " +
             "WHERE udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
             "AND se.title LIKE %:title% " +
             "ORDER BY udlo.lastOpened DESC")

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandService.java
@@ -2,9 +2,10 @@ package com.haru.api.domain.user.service;
 
 import com.haru.api.domain.user.dto.UserRequestDTO;
 import com.haru.api.domain.user.dto.UserResponseDTO;
+import com.haru.api.domain.user.entity.User;
 
 public interface UserCommandService {
-    void signUp(UserRequestDTO.SignUpRequest request);
+    User signUp(UserRequestDTO.SignUpRequest request);
     UserResponseDTO.LoginResponse login(UserRequestDTO.LoginRequest request);
 
     UserResponseDTO.User updateUserInfo(Long userId, UserRequestDTO.UserInfoUpdateRequest request);

--- a/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/user/service/UserCommandServiceImpl.java
@@ -40,7 +40,7 @@ public class UserCommandServiceImpl implements UserCommandService{
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
-    public void signUp(UserRequestDTO.SignUpRequest request) {
+    public User signUp(UserRequestDTO.SignUpRequest request) {
         String password = passwordEncoder.encode(request.getPassword());
         // 이메일 중복 확인
         User foundUser = userRepository.findByEmail(request.getEmail()).orElse(null);
@@ -49,6 +49,7 @@ public class UserCommandServiceImpl implements UserCommandService{
         } else {
             User user = UserConverter.toUsers(request, password);
             userRepository.save(user);
+            return user;
         }
     }
 

--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -70,7 +70,7 @@ public class WorkspaceController {
     }
 
     @Operation(summary = "워크스페이스 초대 수락", description =
-            "# 워크스페이스 초대 수락 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+            "# 워크스페이스 초대 수락 API 입니다."
     )
     @GetMapping("/invite-accept")
     public RedirectView acceptInvite(
@@ -83,18 +83,18 @@ public class WorkspaceController {
             if (result.isSuccess()) {
                 if (result.isAlreadyRegistered()) {
                     // 이미 가입된 사용자면, 로그인 후 워크스페이스 페이지로 이동
-                    redirectUrl = "https://front-end.com/login?redirect=/workspace/" + result.getWorkspaceId(); // FE와 합의 필요
+                    redirectUrl = "https://haru.it.kr/auth/sign-in?redirect=/workspace/" + result.getWorkspaceId();
                 } else {
                     // 미가입 사용자면 회원가입 페이지로 이동 (토큰 정보 포함)
-                    redirectUrl = "https://front-end.com/signup?token=/" + token;
+                    redirectUrl = "https://haru.it.kr/auth/sign-up?token=" + token;
                 }
             } else {
-                redirectUrl = "https://front-end.com/error-page";
+                redirectUrl = "https://haru.it.kr/error-page";
             }
 
             return new RedirectView(redirectUrl);
         } catch (WorkspaceHandler e) {
-            return new RedirectView("https://front-end.com/error-page");
+            return new RedirectView("https://haru.it.kr/error-page");
         }
     }
 

--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -51,4 +51,12 @@ public class WorkspaceConverter {
                 .documents(documentList)
                 .build();
     }
+
+    public static WorkspaceResponseDTO.InvitationAcceptResult toInvitationAcceptResult(boolean isSuccess, boolean isAlreadyRegistered, Workspace workspace) {
+        return WorkspaceResponseDTO.InvitationAcceptResult.builder()
+                .isSuccess(isSuccess)
+                .isAlreadyRegistered(isAlreadyRegistered)
+                .workspaceId(workspace.getId())
+                .build();
+    }
 }

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
@@ -31,4 +31,12 @@ public class WorkspaceResponseDTO {
     public static class DocumentList {
         private List<Document> documents;
     }
+
+    @Getter
+    @Builder
+    public static class InvitationAcceptResult {
+        private boolean isSuccess;
+        private boolean isAlreadyRegistered;
+        private Long workspaceId;
+    }
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.workspace.service;
 
+import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.workspace.dto.WorkspaceRequestDTO;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 
@@ -9,7 +10,9 @@ public interface WorkspaceCommandService {
 
     WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceid, WorkspaceRequestDTO.WorkspaceUpdateRequest request);
 
-    WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String code);
+    WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String token);
+
+    WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String token, User user);
 
     void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -10,4 +10,6 @@ public interface WorkspaceCommandService {
     WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceid, WorkspaceRequestDTO.WorkspaceUpdateRequest request);
 
     WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String code);
+
+    void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandService.java
@@ -9,5 +9,5 @@ public interface WorkspaceCommandService {
 
     WorkspaceResponseDTO.Workspace updateWorkspace(Long userId, Long workspaceid, WorkspaceRequestDTO.WorkspaceUpdateRequest request);
 
-    void acceptInvite(String code);
+    WorkspaceResponseDTO.InvitationAcceptResult acceptInvite(String code);
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceCommandServiceImpl.java
@@ -1,5 +1,14 @@
 package com.haru.api.domain.workspace.service;
 
+import com.haru.api.domain.lastOpened.converter.UserDocumentLastOpenedConverter;
+import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
+import com.haru.api.domain.lastOpened.repository.UserDocumentLastOpenedRepository;
+import com.haru.api.domain.meeting.entity.Meeting;
+import com.haru.api.domain.meeting.repository.MeetingRepository;
+import com.haru.api.domain.moodTracker.entity.MoodTracker;
+import com.haru.api.domain.moodTracker.repository.MoodTrackerRepository;
+import com.haru.api.domain.snsEvent.entity.SnsEvent;
+import com.haru.api.domain.snsEvent.repository.SnsEventRepository;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.user.repository.UserRepository;
 import com.haru.api.domain.userWorkspace.entity.enums.Auth;
@@ -17,11 +26,16 @@ import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import com.haru.api.global.apiPayload.exception.handler.UserWorkspaceHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
 import com.haru.api.global.apiPayload.exception.handler.WorkspaceInvitationHandler;
+import com.haru.api.infra.mail.EmailSender;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +45,15 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
     private final WorkspaceRepository workspaceRepository;
     private final UserWorkspaceRepository userWorkspaceRepository;
     private final WorkspaceInvitationRepository workspaceInvitationRepository;
+    private final MeetingRepository meetingRepository;
+    private final SnsEventRepository snsEventRepository;
+    private final MoodTrackerRepository moodTrackerRepository;
+    private final UserDocumentLastOpenedRepository userDocumentLastOpenedRepository;
+
+    private final EmailSender emailSender;
+
+    @Value("${invite-url}")
+    private String inviteBaseUrl;
 
     @Transactional
     @Override
@@ -114,7 +137,85 @@ public class WorkspaceCommandServiceImpl implements WorkspaceCommandService {
                 .auth(Auth.MEMBER)
                 .build());
 
+        // 각 문서 조회
+        List<Meeting> meetingList = meetingRepository.findAllByWorkspaceId(foundWorkspace.getId());
+        List<SnsEvent> snsEventList = snsEventRepository.findAllByWorkspaceId(foundWorkspace.getId());
+        List<MoodTracker> moodTrackerList = moodTrackerRepository.findAllByWorkspaceId(foundWorkspace.getId());
+
+        // 각 문서 UserDocumentLastOpened로 변환
+        List<UserDocumentLastOpened> userDocumentLastOpenedList = new ArrayList<>();
+        for(Meeting meeting : meetingList)
+            userDocumentLastOpenedList.add(UserDocumentLastOpenedConverter.toUserDocumentLastOpened(meeting, foundUser.get()));
+        for(SnsEvent snsEvent : snsEventList)
+            userDocumentLastOpenedList.add(UserDocumentLastOpenedConverter.toUserDocumentLastOpened(snsEvent, foundUser.get()));
+        for(MoodTracker moodTracker : moodTrackerList)
+            userDocumentLastOpenedList.add(UserDocumentLastOpenedConverter.toUserDocumentLastOpened(moodTracker, foundUser.get()));
+
+        // 워크스페이스에 속해있는 모든 문서를 user_document_last_opened에 추가
+        // last_opened는 null
+        userDocumentLastOpenedList.forEach(userDocumentLastOpened -> {
+            userDocumentLastOpenedRepository.saveAll(userDocumentLastOpenedList);
+        });
+
         return WorkspaceConverter.toInvitationAcceptResult(true, true, foundWorkspace);
+    }
+
+    @Transactional
+    @Override
+    public void sendInviteEmail(Long userId, WorkspaceRequestDTO.WorkspaceInviteEmailRequest request) {
+        Long workspaceId = request.getWorkspaceId();
+        List<String> emails = request.getEmails();
+
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new WorkspaceHandler(ErrorStatus.WORKSPACE_NOT_FOUND));
+
+        userWorkspaceRepository.findByUserAndWorkspace(foundUser, foundWorkspace)
+                .orElseThrow(() -> new UserWorkspaceHandler(ErrorStatus.USER_WORKSPACE_NOT_FOUND));
+
+        // 이메일마다 invitation 생성하여 저장, 초대 수락 토큰 생성, 초대 이메일 발송
+        for(String email: emails) {
+            String token = UUID.randomUUID().toString();
+
+            WorkspaceInvitation workspaceInvitation = WorkspaceInvitation.builder()
+                    .email(email)
+                    .workspace(foundWorkspace)
+                    .token(token)
+                    .isAccepted(false)
+                    .build();
+            workspaceInvitationRepository.save(workspaceInvitation);
+
+            String invitationLink = inviteBaseUrl + "?token=" + token;
+
+            String subject = String.format("[%s] 에서 [%s] 님이 당신을 초대했어요!", foundWorkspace.getTitle(), foundUser.getName());
+            String content = generateInvitationEmailContentHtml(email, foundUser.getName(), foundWorkspace.getTitle(), invitationLink);
+
+            emailSender.send(email, subject, content);
+        }
+
+    }
+
+    private String generateInvitationEmailContentHtml(String invitedEmail, String inviterName, String workspaceName, String invitationLink) {
+        return String.format(
+                "<html>" +
+                        "<head></head>" +
+                        "<body>" +
+                        "  <p>안녕하세요, %s님,</p>" +
+                        "  <p>%s님께서 <b>%s</b> 워크스페이스에 당신을 초대했습니다.</p>" +
+                        "  <p>아래 버튼을 클릭하여 워크스페이스에 합류해 주세요!</p>" +
+                        "  <p style=\"margin-top: 20px;\">" + // 버튼 스타일
+                        "    <a href=\"%s\" " +
+                        "       style=\"display: inline-block; padding: 10px 20px; font-size: 16px; color: white; background-color: #007bff; text-decoration: none; border-radius: 5px;\">" +
+                        "      초대 수락하기" +
+                        "    </a>" +
+                        "  </p>" +
+                        "  <p style=\"margin-top: 30px;\">감사합니다.<br/><b>HaRu 팀 드림</b></p>" +
+                        "</body>" +
+                        "</html>",
+                invitedEmail, inviterName, workspaceName, invitationLink
+        );
     }
 
 }

--- a/src/main/java/com/haru/api/domain/workspaceInvitation/entity/WorkspaceInvitation.java
+++ b/src/main/java/com/haru/api/domain/workspaceInvitation/entity/WorkspaceInvitation.java
@@ -25,8 +25,13 @@ public class WorkspaceInvitation extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workspace_id")
-    Workspace workspace;
+    private Workspace workspace;
 
-    // 초대코드는 pk를 사용해서 해싱
+    private String token;
 
+    private boolean isAccepted = false;
+
+    public void setAccepted() {
+        isAccepted = true;
+    }
 }

--- a/src/main/java/com/haru/api/domain/workspaceInvitation/repository/WorkspaceInvitationRepository.java
+++ b/src/main/java/com/haru/api/domain/workspaceInvitation/repository/WorkspaceInvitationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface WorkspaceInvitationRepository extends JpaRepository<WorkspaceInvitation, Long> {
+    Optional<WorkspaceInvitation> findByToken(String token);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #41

## 📝작업 내용
> 워크스페이스 사용자 초대 기능 구현

## 🔎코드 설명(스크린샷(선택))
- 초대 메일의 '초대 수락하기'를 클릭하면 '/invite-accept?token=~~' 해당 링크로 GET 요청을 날리도록 하여 구현
- token을 토대로 workspace_invitations 테이블을 통해 email을 조회하여 해당 email을 가진 유저가 이미 가입되어있는지 확인
- 이미 가입된 유저인 경우에는 user_workspace에 MEMBER로 삽입하고, 초대받은 워크스페이스에 존재하는 meetings, sns_evenets, mood_trackers를 user_document_last_opened에 last_opened를 null로 하여 삽입하도록 구현
- 이후 리디렉션을 통해 로그인 페이지로 이동하도록 하고, 로그인이 완료되면 초대받은 워크스페이스로 이동하도록 구현
- 미가입 유저인 경우에는 token정보를 다시 url에 담아서 회원가입 페이지로 리디렉션 되도록 구현
- 회원가입 API에 query string으로 token이 입력되면 해당 유저를 워크스페이스에 등록하는 기능까지 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X