### PR TITLE
feat/#73: 워크스페이스 문서 검색 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -22,9 +22,8 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN Meeting mt ON udlo.id.documentId = mt.id " +
             "WHERE udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
-            "AND mt.title LIKE %:title% " +
-            "ORDER BY udlo.lastOpened DESC")
-    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);
+            "AND mt.title LIKE %:title%")
+    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title);
 
     List<Meeting> findAllByWorkspaceId(Long workspaceId);
 }

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -21,7 +21,6 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN MoodTracker mt ON udlo.id.documentId = mt.id " +
             "WHERE udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
-            "AND mt.title LIKE %:title% " +
-            "ORDER BY udlo.lastOpened DESC")
-    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);
+            "AND mt.title LIKE %:title%")
+    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -20,9 +20,8 @@ public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN SnsEvent se ON udlo.id.documentId = se.id " +
             "WHERE udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
-            "AND se.title LIKE %:title% " +
-            "ORDER BY udlo.lastOpened DESC")
-    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);
+            "AND se.title LIKE %:title%")
+    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title);
 
     List<SnsEvent> findAllByWorkspaceId(Long workspaceId);
 }

--- a/src/main/java/com/haru/api/domain/userWorkspace/dto/UserWorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/dto/UserWorkspaceResponseDTO.java
@@ -10,11 +10,13 @@ public class UserWorkspaceResponseDTO {
     public static class UserWorkspaceWithTitle {
         private Long workspaceId;
         private String title;
+        private String imageUrl;
         private Boolean isOwner;
 
-        public UserWorkspaceWithTitle(Long workspaceId, String title, Boolean isOwner) {
+        public UserWorkspaceWithTitle(Long workspaceId, String title, String imageUrl, Boolean isOwner) {
             this.workspaceId = workspaceId;
             this.title = title;
+            this.imageUrl = imageUrl;
             this.isOwner = isOwner;
         }
     }

--- a/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
+++ b/src/main/java/com/haru/api/domain/userWorkspace/repository/UserWorkspaceRepository.java
@@ -16,6 +16,7 @@ public interface UserWorkspaceRepository extends JpaRepository<UserWorkspace, Lo
     @Query("SELECT new com.haru.api.domain.userWorkspace.dto.UserWorkspaceResponseDTO$UserWorkspaceWithTitle(" +
             "uw.workspace.id, " +
             "uw.workspace.title, " +
+            "uw.workspace.imageUrl, " +
             "CASE WHEN uw.auth = 'ADMIN' THEN true ELSE false END) " +
             "FROM UserWorkspace uw " +
             "WHERE uw.user.id = :userId")

--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -26,8 +26,10 @@ public class WorkspaceController {
     private final UserWorkspaceQueryService userWorkspaceQueryService;
     private final WorkspaceQueryService workspaceQueryService;
 
-    @Operation(summary = "워크스페이스 생성", description =
-            "# 워크스페이스 생성 API 입니다. 워크스페이스 제목과 초대하고자 하는 사람의 이메일을 입력해주세요."
+    @Operation(
+            summary = "워크스페이스 생성",
+            description = "# [v0.0 (2025-07-31)](https://www.notion.so/workspace-2265da7802c5808e9405f37866203a43)" +
+                    " 워크스페이스 생성 API 입니다. 워크스페이스 제목과 사진을 첨부해주세요."
     )
     @PostMapping
     public ApiResponse<WorkspaceResponseDTO.Workspace> createWorkspace(
@@ -41,8 +43,10 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(workspace);
     }
 
-    @Operation(summary = "워크스페이스 리스트 제목 조회", description =
-            "# 워크스페이스 리스트 제목 조회 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    @Operation(
+            summary = "워크스페이스 리스트 제목 조회",
+            description = "# [v1.0 (2025-07-31)](https://www.notion.so/workspace-2265da7802c5801e9c83f6675bbc9de7)" +
+                    " 워크스페이스 리스트 제목 조회 API 입니다. jwt 토큰을 헤더에 넣어주세요"
     )
     @GetMapping("/me")
     public ApiResponse<List<UserWorkspaceResponseDTO.UserWorkspaceWithTitle>> getWorkspaceWithTitleList() {
@@ -54,8 +58,10 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(workspaceWithTitleList);
     }
 
-    @Operation(summary = "워크스페이스 수정", description =
-            "# 워크스페이스 수정 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    @Operation(
+            summary = "워크스페이스 수정",
+            description = "# [v1.0 (2025-07-31)](https://www.notion.so/workspace-2265da7802c580ebb332e868007671a7)" +
+                    " 워크스페이스 수정 API 입니다. jwt 토큰을 헤더에 넣어주세요"
     )
     @PatchMapping("/{workspaceId}")
     public ApiResponse<WorkspaceResponseDTO.Workspace> updateWorkspace(
@@ -69,8 +75,10 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(workspace);
     }
 
-    @Operation(summary = "워크스페이스 초대 수락", description =
-            "# 워크스페이스 초대 수락 API 입니다."
+    @Operation(
+            summary = "워크스페이스 초대 수락",
+            description = "# [v1.0 (2025-07-31)](https://www.notion.so/workspace-22e5da7802c580a3baf7c52a9fd8d45e?pvs=25)" +
+                    " 워크스페이스 초대 수락 API 입니다."
     )
     @GetMapping("/invite-accept")
     public RedirectView acceptInvite(
@@ -98,8 +106,10 @@ public class WorkspaceController {
         }
     }
 
-    @Operation(summary = "워크스페이스 문서 검색", description =
-            "# 워크스페이스 문서 검색 API 입니다. jwt 토큰을 헤더에 넣고, path variable로 workspaceId, query string에 문서 제목을 넣어주세요"
+    @Operation(
+            summary = "워크스페이스 문서 검색",
+            description = "# [v1.0 (2025-07-31)](https://www.notion.so/2265da7802c580ca9a33eb9ba7ddec29?pvs=25)" +
+                    " 워크스페이스 문서 검색 API 입니다. jwt 토큰을 헤더에 넣고, path variable로 workspaceId, query string에 문서 제목을 넣어주세요"
     )
     @GetMapping("/{workspaceId}")
     public ApiResponse<WorkspaceResponseDTO.DocumentList> getDocument(
@@ -113,8 +123,10 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(documentList);
     }
 
-    @Operation(summary = "워크스페이스 초대 메일 발송", description =
-            "# 워크스페이스 초대 메일 발송 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    @Operation(
+            summary = "워크스페이스 초대 메일 발송",
+            description = "# [v1.0 (2025-07-31)](https://www.notion.so/workspace-2385da7802c5804c86a5c1c7ca3b13cf?pvs=25)" +
+                    " 워크스페이스 초대 메일 발송 API 입니다. jwt 토큰을 헤더에 넣어주세요"
     )
     @PostMapping("/invite") ApiResponse<Void> sendInviteEmail(
             @RequestBody WorkspaceRequestDTO.WorkspaceInviteEmailRequest request

--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -14,7 +14,7 @@ public class WorkspaceConverter {
     public static WorkspaceResponseDTO.Workspace toWorkspaceDTO(Workspace workspace) {
         return WorkspaceResponseDTO.Workspace.builder()
                 .workspaceId(workspace.getId())
-                .name(workspace.getTitle())
+                .title(workspace.getTitle())
                 .imageUrl(workspace.getImageUrl())
                 .build();
     }

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
@@ -13,7 +13,7 @@ public class WorkspaceResponseDTO {
     @Builder
     public static class Workspace {
         private Long workspaceId;
-        private String name;
+        private String title;
         private String imageUrl;
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #73

## 📝작업 내용
> 워크스페이스 문서 검색 기능 구현

## 🔎코드 설명(스크린샷(선택))
- 각 문서별로 title이 일치하는 모든 문서를 검색해서 last opened를 기준으로 내림차순으로 정렬하여 반환하도록 구현
- null이 후순위로 가도록 구현하였고, lastOpened가 null이어도 정상적으로 동작
- 문서 검색하는 쿼리메서드에서 order by lastOpened 삭제
- workspace 제목 리스트 조회할 때 imageUrl도 함께 반환하도록 수정
- workspace 스웨거 설명란에 각 API 명세서 노션 페이지 마크다운으로 하이퍼링크 첨부

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X