### PR TITLE
feat/#124: SNS 이벤트 조회관련 API 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
@@ -3,6 +3,7 @@ package com.haru.api.domain.snsEvent.controller;
 import com.haru.api.domain.snsEvent.dto.SnsEventRequestDTO;
 import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
 import com.haru.api.domain.snsEvent.service.SnsEventCommandService;
+import com.haru.api.domain.user.security.jwt.SecurityUtil;
 import com.haru.api.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,20 @@ public class SnsEventController {
     ) {
         return ApiResponse.onSuccess(
                 snsEventCommandService.createSnsEvent(workspaceId, request)
+        );
+    }
+
+    @Operation(
+            summary = "SNS 이벤트 리스트 조회 API",
+            description = "SNS 이벤트 리스트 조회 API입니다. Header에 access token을 넣고 Path Variable에는 workspaceId를 넣어 요청해주세요."
+    )
+    @GetMapping("/{workspaceId}/list")
+    public ApiResponse<SnsEventResponseDTO.GetSnsEventListRequest> getSnsEventList(
+            @PathVariable Long workspaceId
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        return ApiResponse.onSuccess(
+                snsEventCommandService.getSnsEventList(userId, workspaceId)
         );
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
@@ -43,4 +43,18 @@ public class SnsEventController {
                 snsEventCommandService.getSnsEventList(userId, workspaceId)
         );
     }
+
+    @Operation(
+            summary = "SNS 이벤트 조회 API",
+            description = "SNS 이벤트 조회 API입니다. Header에 access token을 넣고 Path Variable에는 snsEventId를 넣어 요청해주세요."
+    )
+    @GetMapping("/{snsEventId}")
+    public ApiResponse<SnsEventResponseDTO.GetSnsEventRequest> getSnsEvent(
+            @PathVariable Long snsEventId
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+        return ApiResponse.onSuccess(
+                snsEventCommandService.getSnsEvent(userId, snsEventId)
+        );
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/converter/SnsEventConverter.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/converter/SnsEventConverter.java
@@ -6,14 +6,16 @@ import com.haru.api.domain.snsEvent.entity.Participant;
 import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.snsEvent.entity.Winner;
 import com.haru.api.domain.user.entity.User;
-import com.haru.api.domain.user.entity.enums.Status;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class SnsEventConverter {
-    public static SnsEvent toSnsEvent(SnsEventRequestDTO.CreateSnsRequest request, User user) {
+    public static SnsEvent toSnsEvent(
+            SnsEventRequestDTO.CreateSnsRequest request,
+            User user
+    ) {
         return SnsEvent.builder()
                 .title(request.getTitle())
                 .snsLink(request.getSnsEventLink())
@@ -35,24 +37,58 @@ public class SnsEventConverter {
                 .build();
     }
 
-    public static SnsEventResponseDTO.GetSnsEventListRequest toGetSnsEventListRequest(List<SnsEvent> SnsEventList) {
-        List<SnsEventResponseDTO.SnsEventList> snsEventList = SnsEventList.stream()
+    public static SnsEventResponseDTO.GetSnsEventListRequest toGetSnsEventListRequest(List<SnsEvent> snsEventList) {
+        List<SnsEventResponseDTO.SnsEventResponse> snsEventResponseList = snsEventList.stream()
                 .map(SnsEventConverter::toSnsEventList)
                 .collect(Collectors.toList());
 
         return SnsEventResponseDTO.GetSnsEventListRequest.builder()
-                .snsEventList(snsEventList)
+                .snsEventList(snsEventResponseList)
                 .build();
     }
 
-    public static SnsEventResponseDTO.SnsEventList toSnsEventList(SnsEvent snsEvent) {
-        return SnsEventResponseDTO.SnsEventList.builder()
+    public static SnsEventResponseDTO.SnsEventResponse toSnsEventList(SnsEvent snsEvent) {
+        return SnsEventResponseDTO.SnsEventResponse.builder()
                 .snsEventId(snsEvent.getId())
                 .title(snsEvent.getTitle())
                 .participantCount(snsEvent.getParticipantList().size())
                 .winnerCount(snsEvent.getWinnerList().size())
                 .snsLink(snsEvent.getSnsLink())
                 .updatedAt(snsEvent.getUpdatedAt())
+                .build();
+    }
+
+    public static SnsEventResponseDTO.GetSnsEventRequest toGetSnsEventRequest(
+            SnsEvent snsEvent,
+            List<Participant> participantList,
+            List<Winner> winnerList
+    ) {
+        List<SnsEventResponseDTO.ParticipantResponse> participantResponseList = participantList.stream()
+                .map(SnsEventConverter::toParticipantResponse)
+                .collect(Collectors.toList());
+        List<SnsEventResponseDTO.WinnerResponse> winnerResponseList = winnerList.stream()
+                .map(SnsEventConverter::toWinnerResponse)
+                .collect(Collectors.toList());
+
+        return SnsEventResponseDTO.GetSnsEventRequest.builder()
+                .title(snsEvent.getTitle())
+                .userName(snsEvent.getCreator().getName())
+                .updatedAt(snsEvent.getUpdatedAt())
+                .participantList(participantResponseList)
+                .winnerList(winnerResponseList)
+                .snsLink(snsEvent.getSnsLink())
+                .build();
+    }
+
+    public static SnsEventResponseDTO.ParticipantResponse toParticipantResponse(Participant participant) {
+        return SnsEventResponseDTO.ParticipantResponse.builder()
+                .account(participant.getNickname())
+                .build();
+    }
+
+    public static SnsEventResponseDTO.WinnerResponse toWinnerResponse(Winner winner) {
+        return SnsEventResponseDTO.WinnerResponse.builder()
+                .account(winner.getNickname())
                 .build();
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/converter/SnsEventConverter.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/converter/SnsEventConverter.java
@@ -9,6 +9,8 @@ import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.user.entity.enums.Status;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class SnsEventConverter {
     public static SnsEvent toSnsEvent(SnsEventRequestDTO.CreateSnsRequest request, User user) {
@@ -30,6 +32,27 @@ public class SnsEventConverter {
     public static Winner toWinner(String nickname) {
         return Winner.builder()
                 .nickname(nickname)
+                .build();
+    }
+
+    public static SnsEventResponseDTO.GetSnsEventListRequest toGetSnsEventListRequest(List<SnsEvent> SnsEventList) {
+        List<SnsEventResponseDTO.SnsEventList> snsEventList = SnsEventList.stream()
+                .map(SnsEventConverter::toSnsEventList)
+                .collect(Collectors.toList());
+
+        return SnsEventResponseDTO.GetSnsEventListRequest.builder()
+                .snsEventList(snsEventList)
+                .build();
+    }
+
+    public static SnsEventResponseDTO.SnsEventList toSnsEventList(SnsEvent snsEvent) {
+        return SnsEventResponseDTO.SnsEventList.builder()
+                .snsEventId(snsEvent.getId())
+                .title(snsEvent.getTitle())
+                .participantCount(snsEvent.getParticipantList().size())
+                .winnerCount(snsEvent.getWinnerList().size())
+                .snsLink(snsEvent.getSnsLink())
+                .updatedAt(snsEvent.getUpdatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventRequestDTO.java
@@ -5,6 +5,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 public class SnsEventRequestDTO {
+
     @Getter
     @Setter
     @NoArgsConstructor

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
@@ -51,14 +51,14 @@ public class SnsEventResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetSnsEventListRequest {
-        private List<SnsEventList> snsEventList;
+        private List<SnsEventResponse> snsEventList;
     }
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SnsEventList {
+    public static class SnsEventResponse {
         private Long snsEventId;
         private String title;
         private int participantCount;
@@ -66,5 +66,35 @@ public class SnsEventResponseDTO {
         private String snsLink;
         @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime updatedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetSnsEventRequest {
+        private String title;
+        private String userName;
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime updatedAt;
+        private List<ParticipantResponse> participantList;
+        private List<WinnerResponse> winnerList;
+        private String snsLink;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ParticipantResponse {
+        private String account;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class WinnerResponse {
+        private String account;
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/dto/SnsEventResponseDTO.java
@@ -1,8 +1,7 @@
 package com.haru.api.domain.snsEvent.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -45,5 +44,27 @@ public class SnsEventResponseDTO {
     public static class From {
         private String id;
         private String username;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetSnsEventListRequest {
+        private List<SnsEventList> snsEventList;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SnsEventList {
+        private Long snsEventId;
+        private String title;
+        private int participantCount;
+        private int winnerCount;
+        private String snsLink;
+        @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/ParticipantRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/ParticipantRepository.java
@@ -1,7 +1,11 @@
 package com.haru.api.domain.snsEvent.repository;
 
 import com.haru.api.domain.snsEvent.entity.Participant;
+import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    List<Participant> findAllBySnsEvent(SnsEvent foundSnsEvent);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -2,6 +2,7 @@ package com.haru.api.domain.snsEvent.repository;
 
 import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
+import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -25,4 +26,6 @@ public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title, Pageable pageable);
 
     List<SnsEvent> findAllByWorkspaceId(Long workspaceId);
+
+    List<SnsEvent> findAllByWorkspace(Workspace foundWorkspace);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/WinnerRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/WinnerRepository.java
@@ -1,9 +1,13 @@
 package com.haru.api.domain.snsEvent.repository;
 
+import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.snsEvent.entity.Winner;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface WinnerRepository extends JpaRepository<Winner, Long> {
+    List<Winner> findAllBySnsEvent(SnsEvent foundSnsEvent);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
@@ -7,4 +7,6 @@ public interface SnsEventCommandService {
     SnsEventResponseDTO.CreateSnsEventResponse createSnsEvent(Long workspaceId, SnsEventRequestDTO.CreateSnsRequest request);
 
     SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId);
+
+    SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(Long userId, Long snsEventId);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
@@ -5,4 +5,6 @@ import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
 
 public interface SnsEventCommandService {
     SnsEventResponseDTO.CreateSnsEventResponse createSnsEvent(Long workspaceId, SnsEventRequestDTO.CreateSnsRequest request);
+
+    SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -196,4 +196,15 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
 
         return list.subList(0, n); // 앞에서 n개만 추출
     }
+
+    public SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId) {
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new WorkspaceHandler(WORKSPACE_NOT_FOUND));
+        UserWorkspace foundUserWorkSapce = userWorkspaceRepository.findByUserAndWorkspace(foundUser, foundWorkspace)
+                .orElseThrow(() -> new MemberHandler(NOT_BELONG_TO_WORKSPACE));
+        List<SnsEvent> snsEventList = snsEventRepository.findAllByWorkspace(foundWorkspace);
+        return SnsEventConverter.toGetSnsEventListRequest(snsEventList);
+    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -207,4 +207,18 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         List<SnsEvent> snsEventList = snsEventRepository.findAllByWorkspace(foundWorkspace);
         return SnsEventConverter.toGetSnsEventListRequest(snsEventList);
     }
+
+    public SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(Long userId, Long snsEventId) {
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
+        SnsEvent foundSnsEvent = snsEventRepository.findById(snsEventId)
+                .orElseThrow(() -> new SnsEventHandler(SNS_EVENT_NOT_FOUND));
+        List<Participant> participantList = participantRepository.findAllBySnsEvent(foundSnsEvent);
+        List<Winner> winnerList = winnerRepository.findAllBySnsEvent(foundSnsEvent);
+        return SnsEventConverter.toGetSnsEventRequest(
+                foundSnsEvent,
+                participantList,
+                winnerList
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #124

## 📝작업 내용
> SNS 이벤트 조회 API 구현
> SNS 이벤트 리스트 조회 API 구현

## 🔎코드 설명(스크린샷(선택))
> SNS 이벤트 조회 API 구현
> SNS 이벤트 리스트 조회 API 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x