### PR TITLE
feat/#92: 워크스페이스 사이드바 최근 문서 조회 기능 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -19,10 +19,10 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
             "mt.title, " +
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
-            "FROM UserDocumentLastOpened  udlo " +
+            "FROM UserDocumentLastOpened udlo " +
             "JOIN Meeting mt ON udlo.id.documentId = mt.id " +
             "WHERE udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
-            "AND mt.title LIKE %:title%")
+            "AND (:title IS NULL OR :title = '' OR mt.title LIKE %:title%)")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title);
 
     List<Meeting> findAllByWorkspaceId(Long workspaceId);

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -21,6 +21,6 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN MoodTracker mt ON udlo.id.documentId = mt.id " +
             "WHERE udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
-            "AND mt.title LIKE %:title%")
+            "AND (:title IS NULL OR :title = '' OR mt.title LIKE %:title%)")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -20,7 +20,7 @@ public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
             "FROM UserDocumentLastOpened  udlo " +
             "JOIN SnsEvent se ON udlo.id.documentId = se.id " +
             "WHERE udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
-            "AND se.title LIKE %:title%")
+            "AND (:title IS NULL OR :title = '' OR se.title LIKE %:title%)")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long userId, String title);
 
     List<SnsEvent> findAllByWorkspaceId(Long workspaceId);

--- a/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/haru/api/domain/workspace/controller/WorkspaceController.java
@@ -143,4 +143,20 @@ public class WorkspaceController {
         return ApiResponse.onSuccess(null);
     }
 
+    @Operation(
+            summary = "사이드바 최근 문서 조회",
+            description = "# [v1.0 (2025-07-31)](https://www.notion.so/22a5da7802c58014b70fce5cde93e3f2?pvs=25)" +
+                    " 사이드바 최근 문서 조회 API 입니다. jwt 토큰을 헤더에 넣어주세요"
+    )
+    @GetMapping("/{workspaceId}/sidebar")
+    public ApiResponse<WorkspaceResponseDTO.DocumentWithoutLastOpenedList> getSidebar(
+            @PathVariable Long workspaceId
+    ) {
+        Long userId = SecurityUtil.getCurrentUserId();
+
+        WorkspaceResponseDTO.DocumentWithoutLastOpenedList documentWithoutLastOpenedList = workspaceQueryService.getDocumentWithoutLastOpenedList(userId, workspaceId);
+
+        return ApiResponse.onSuccess(documentWithoutLastOpenedList);
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -1,13 +1,8 @@
 package com.haru.api.domain.workspace.converter;
 
-import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
-import com.haru.api.domain.meeting.entity.Meeting;
-import com.haru.api.domain.moodTracker.entity.MoodTracker;
-import com.haru.api.domain.snsEvent.entity.SnsEvent;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.entity.Workspace;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public class WorkspaceConverter {
@@ -16,33 +11,6 @@ public class WorkspaceConverter {
                 .workspaceId(workspace.getId())
                 .title(workspace.getTitle())
                 .imageUrl(workspace.getImageUrl())
-                .build();
-    }
-
-    public static WorkspaceResponseDTO.Document toDocument(Meeting meeting, LocalDateTime lastOpened) {
-        return WorkspaceResponseDTO.Document.builder()
-                .documentId(meeting.getId())
-                .documentType(DocumentType.AI_MEETING_MANAGER)
-                .title(meeting.getTitle())
-                .lastOpened(lastOpened)
-                .build();
-    }
-
-    public static WorkspaceResponseDTO.Document toDocument(SnsEvent snsEvent, LocalDateTime lastOpened) {
-        return WorkspaceResponseDTO.Document.builder()
-                .documentId(snsEvent.getId())
-                .documentType(DocumentType.SNS_EVENT_ASSISTANT)
-                .title(snsEvent.getTitle())
-                .lastOpened(lastOpened)
-                .build();
-    }
-
-    public static WorkspaceResponseDTO.Document toDocument(MoodTracker moodTracker, LocalDateTime lastOpened) {
-        return WorkspaceResponseDTO.Document.builder()
-                .documentId(moodTracker.getId())
-                .documentType(DocumentType.TEAM_MOOD_TRACKER)
-                .title(moodTracker.getTitle())
-                .lastOpened(lastOpened)
                 .build();
     }
 
@@ -57,6 +25,20 @@ public class WorkspaceConverter {
                 .isSuccess(isSuccess)
                 .isAlreadyRegistered(isAlreadyRegistered)
                 .workspaceId(workspace.getId())
+                .build();
+    }
+
+    public static WorkspaceResponseDTO.DocumentWithoutLastOpened toDocumentWithoutLastOpened(WorkspaceResponseDTO.Document document) {
+        return WorkspaceResponseDTO.DocumentWithoutLastOpened.builder()
+                .documentId(document.getDocumentId())
+                .documentType(document.getDocumentType())
+                .title(document.getTitle())
+                .build();
+    }
+
+    public static WorkspaceResponseDTO.DocumentWithoutLastOpenedList toDocumentWithoutLastOpenedList(List<WorkspaceResponseDTO.DocumentWithoutLastOpened> documentList) {
+        return WorkspaceResponseDTO.DocumentWithoutLastOpenedList.builder()
+                .documents(documentList)
                 .build();
     }
 }

--- a/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
+++ b/src/main/java/com/haru/api/domain/workspace/dto/WorkspaceResponseDTO.java
@@ -39,4 +39,18 @@ public class WorkspaceResponseDTO {
         private boolean isAlreadyRegistered;
         private Long workspaceId;
     }
+
+    @Getter
+    @Builder
+    public static class DocumentWithoutLastOpened {
+        private Long documentId;
+        private String title;
+        private DocumentType documentType;
+    }
+
+    @Getter
+    @Builder
+    public static class DocumentWithoutLastOpenedList {
+        private List<DocumentWithoutLastOpened> documents;
+    }
 }

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryService.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryService.java
@@ -5,4 +5,6 @@ import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 public interface WorkspaceQueryService {
 
     WorkspaceResponseDTO.DocumentList getDocuments(Long userId, Long workspaceId, String title);
+
+    WorkspaceResponseDTO.DocumentWithoutLastOpenedList getDocumentWithoutLastOpenedList(Long userId, Long workspaceId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #92

## 📝작업 내용
> 워크스페이스 사이드바 최근 문서 조회 기능 구현

## 🔎코드 설명(스크린샷(선택))
- workspace에 속해있는 문서중에서 가장 최근에 조회된 문서 최대 5개를 반환하도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X