### PR TITLE
feat/#102: 문서가 조회될 때 마다 last opened 업데이트 하도록 구현

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
@@ -18,6 +19,7 @@ public class UserDocumentId implements Serializable {
     private Long userId;
 
     @Column(name = "document_id")
+    @Getter
     private Long documentId;
 
     @Column(name = "document_type")

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
@@ -31,4 +31,8 @@ public class UserDocumentLastOpened {
     @Column(name = "last_opened")
     private LocalDateTime lastOpened;
 
+    public void updateLastOpened(LocalDateTime lastOpened) {
+        this.lastOpened = lastOpened;
+    }
+
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
@@ -1,10 +1,11 @@
 package com.haru.api.domain.lastOpened.repository;
 
+import com.haru.api.domain.lastOpened.entity.UserDocumentId;
 import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface UserDocumentLastOpenedRepository extends JpaRepository<UserDocumentLastOpened, Long> {
-
+    Optional<UserDocumentLastOpened> findById(UserDocumentId id);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
@@ -1,0 +1,8 @@
+package com.haru.api.domain.lastOpened.service;
+
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+
+public interface UserDocumentLastOpenedService {
+
+    void updateLastOpened(Long userId, DocumentType documentType, Long documentId);
+}

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -1,0 +1,47 @@
+package com.haru.api.domain.lastOpened.service;
+
+import com.haru.api.domain.lastOpened.entity.UserDocumentId;
+import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+import com.haru.api.domain.lastOpened.repository.UserDocumentLastOpenedRepository;
+import com.haru.api.domain.user.entity.User;
+import com.haru.api.domain.user.repository.UserRepository;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpenedService {
+
+    private final UserDocumentLastOpenedRepository userDocumentLastOpenedRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void updateLastOpened(Long userId, DocumentType documentType, Long documentId) {
+        UserDocumentId id = new UserDocumentId(userId, documentId, documentType);
+
+        UserDocumentLastOpened record = userDocumentLastOpenedRepository.findById(id)
+                .orElseGet(() -> {
+                    User foundUser = userRepository.findById(userId)
+                            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                    return UserDocumentLastOpened.builder()
+                            .id(id)
+                            .user(foundUser)
+                            .build();
+                });
+
+        record.updateLastOpened(LocalDateTime.now());
+        userDocumentLastOpenedRepository.save(record);
+
+        log.info("userDocumentLastOpened updated for userId: {}. documentId:{}", record.getUser().getId(), record.getId().getDocumentId());
+    }
+
+}

--- a/src/main/java/com/haru/api/domain/meeting/service/MeetingQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/meeting/service/MeetingQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.meeting.service;
 
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.meeting.converter.MeetingConverter;
 import com.haru.api.domain.meeting.dto.MeetingResponseDTO;
 import com.haru.api.domain.meeting.entity.Meeting;
@@ -7,10 +8,10 @@ import com.haru.api.domain.meeting.repository.MeetingRepository;
 import com.haru.api.domain.user.entity.User;
 import com.haru.api.domain.user.repository.UserRepository;
 import com.haru.api.domain.userWorkspace.entity.UserWorkspace;
-import com.haru.api.domain.userWorkspace.entity.enums.Auth;
 import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
 import com.haru.api.domain.workspace.entity.Workspace;
 import com.haru.api.domain.workspace.repository.WorkspaceRepository;
+import com.haru.api.global.annotation.TrackLastOpened;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MeetingHandler;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
@@ -49,6 +50,7 @@ public class MeetingQueryServiceImpl implements MeetingQueryService{
     }
 
     @Override
+    @TrackLastOpened(type = DocumentType.AI_MEETING_MANAGER)
     public MeetingResponseDTO.getMeetingProceeding getMeetingProceeding(Long userId, Long meetingId){
         User foundUser = userRepository.findById(userId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/service/MoodTrackerQueryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.moodTracker.service;
 
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.moodTracker.converter.MoodTrackerConverter;
 import com.haru.api.domain.moodTracker.dto.MoodTrackerResponseDTO;
 import com.haru.api.domain.moodTracker.entity.MoodTracker;
@@ -13,6 +14,7 @@ import com.haru.api.domain.userWorkspace.entity.enums.Auth;
 import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
 import com.haru.api.domain.workspace.entity.Workspace;
 import com.haru.api.domain.workspace.repository.WorkspaceRepository;
+import com.haru.api.global.annotation.TrackLastOpened;
 import com.haru.api.global.apiPayload.code.status.ErrorStatus;
 import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
 import com.haru.api.global.apiPayload.exception.handler.MoodTrackerHandler;
@@ -76,6 +78,7 @@ public class MoodTrackerQueryServiceImpl implements MoodTrackerQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    @TrackLastOpened(type = DocumentType.TEAM_MOOD_TRACKER)
     public MoodTrackerResponseDTO.QuestionResult getQuestionResult(Long userId, Long moodTrackerId) {
         MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
                 .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
@@ -87,6 +90,7 @@ public class MoodTrackerQueryServiceImpl implements MoodTrackerQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    @TrackLastOpened(type = DocumentType.TEAM_MOOD_TRACKER)
     public MoodTrackerResponseDTO.ReportResult getReportResult(Long userId, Long moodTrackerId) {
         MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
                 .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
@@ -120,6 +124,7 @@ public class MoodTrackerQueryServiceImpl implements MoodTrackerQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    @TrackLastOpened(type = DocumentType.TEAM_MOOD_TRACKER)
     public MoodTrackerResponseDTO.ResponseResult getResponseResult(Long userId, Long moodTrackerId) {
         MoodTracker foundMoodTracker = moodTrackerRepository.findById(moodTrackerId)
                 .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));

--- a/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/controller/SnsEventController.java
@@ -3,6 +3,7 @@ package com.haru.api.domain.snsEvent.controller;
 import com.haru.api.domain.snsEvent.dto.SnsEventRequestDTO;
 import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
 import com.haru.api.domain.snsEvent.service.SnsEventCommandService;
+import com.haru.api.domain.snsEvent.service.SnsEventQueryService;
 import com.haru.api.domain.user.security.jwt.SecurityUtil;
 import com.haru.api.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class SnsEventController {
 
     private final SnsEventCommandService snsEventCommandService;
+    private final SnsEventQueryService snsEventQueryService;
 
     @Operation(
             summary = "SNS 이벤트 생성 API",
@@ -67,7 +69,7 @@ public class SnsEventController {
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
         return ApiResponse.onSuccess(
-                snsEventCommandService.getSnsEventList(userId, workspaceId)
+                snsEventQueryService.getSnsEventList(userId, workspaceId)
         );
     }
 
@@ -81,7 +83,7 @@ public class SnsEventController {
     ) {
         Long userId = SecurityUtil.getCurrentUserId();
         return ApiResponse.onSuccess(
-                snsEventCommandService.getSnsEvent(userId, snsEventId)
+                snsEventQueryService.getSnsEvent(userId, snsEventId)
         );
     }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandService.java
@@ -6,11 +6,8 @@ import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
 public interface SnsEventCommandService {
     SnsEventResponseDTO.CreateSnsEventResponse createSnsEvent(Long workspaceId, SnsEventRequestDTO.CreateSnsRequest request);
 
-    void updateSnsEventTitle(Long userId, Long snsEvnetId, SnsEventRequestDTO.UpdateSnsEventRequest request);
+    void updateSnsEventTitle(Long userId, Long snsEventId, SnsEventRequestDTO.UpdateSnsEventRequest request);
 
-    void deleteSnsEvent(Long userId, Long snsEvnetId);
+    void deleteSnsEvent(Long userId, Long snsEventId);
 
-    SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId);
-
-    SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(Long userId, Long snsEventId);
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventCommandServiceImpl.java
@@ -231,29 +231,5 @@ public class SnsEventCommandServiceImpl implements SnsEventCommandService{
         }
         snsEventRepository.delete(foundSnsEvent);
     }
-      
-    public SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId) {
-        User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
-        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
-                .orElseThrow(() -> new WorkspaceHandler(WORKSPACE_NOT_FOUND));
-        UserWorkspace foundUserWorkSapce = userWorkspaceRepository.findByUserAndWorkspace(foundUser, foundWorkspace)
-                .orElseThrow(() -> new MemberHandler(NOT_BELONG_TO_WORKSPACE));
-        List<SnsEvent> snsEventList = snsEventRepository.findAllByWorkspace(foundWorkspace);
-        return SnsEventConverter.toGetSnsEventListRequest(snsEventList);
-    }
 
-    public SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(Long userId, Long snsEventId) {
-        User foundUser = userRepository.findById(userId)
-                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
-        SnsEvent foundSnsEvent = snsEventRepository.findById(snsEventId)
-                .orElseThrow(() -> new SnsEventHandler(SNS_EVENT_NOT_FOUND));
-        List<Participant> participantList = participantRepository.findAllBySnsEvent(foundSnsEvent);
-        List<Winner> winnerList = winnerRepository.findAllBySnsEvent(foundSnsEvent);
-        return SnsEventConverter.toGetSnsEventRequest(
-                foundSnsEvent,
-                participantList,
-                winnerList
-        );
-    }
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryService.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryService.java
@@ -1,0 +1,10 @@
+package com.haru.api.domain.snsEvent.service;
+
+import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
+
+public interface SnsEventQueryService {
+
+    SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId);
+
+    SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(Long userId, Long snsEventId);
+}

--- a/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/service/SnsEventQueryServiceImpl.java
@@ -1,0 +1,68 @@
+package com.haru.api.domain.snsEvent.service;
+
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+import com.haru.api.domain.snsEvent.converter.SnsEventConverter;
+import com.haru.api.domain.snsEvent.dto.SnsEventResponseDTO;
+import com.haru.api.domain.snsEvent.entity.Participant;
+import com.haru.api.domain.snsEvent.entity.SnsEvent;
+import com.haru.api.domain.snsEvent.entity.Winner;
+import com.haru.api.domain.snsEvent.repository.ParticipantRepository;
+import com.haru.api.domain.snsEvent.repository.SnsEventRepository;
+import com.haru.api.domain.snsEvent.repository.WinnerRepository;
+import com.haru.api.domain.user.entity.User;
+import com.haru.api.domain.user.repository.UserRepository;
+import com.haru.api.domain.userWorkspace.entity.UserWorkspace;
+import com.haru.api.domain.userWorkspace.repository.UserWorkspaceRepository;
+import com.haru.api.domain.workspace.entity.Workspace;
+import com.haru.api.domain.workspace.repository.WorkspaceRepository;
+import com.haru.api.global.annotation.TrackLastOpened;
+import com.haru.api.global.apiPayload.exception.handler.MemberHandler;
+import com.haru.api.global.apiPayload.exception.handler.SnsEventHandler;
+import com.haru.api.global.apiPayload.exception.handler.WorkspaceHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.haru.api.global.apiPayload.code.status.ErrorStatus.*;
+
+@Service
+@RequiredArgsConstructor
+public class SnsEventQueryServiceImpl implements SnsEventQueryService {
+
+    private final UserRepository userRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final UserWorkspaceRepository userWorkspaceRepository;
+    private final SnsEventRepository snsEventRepository;
+    private final ParticipantRepository participantRepository;
+    private final WinnerRepository winnerRepository;
+
+    @Override
+    public SnsEventResponseDTO.GetSnsEventListRequest getSnsEventList(Long userId, Long workspaceId) {
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
+        Workspace foundWorkspace = workspaceRepository.findById(workspaceId)
+                .orElseThrow(() -> new WorkspaceHandler(WORKSPACE_NOT_FOUND));
+        UserWorkspace foundUserWorkSpace = userWorkspaceRepository.findByUserAndWorkspace(foundUser, foundWorkspace)
+                .orElseThrow(() -> new MemberHandler(NOT_BELONG_TO_WORKSPACE));
+        List<SnsEvent> snsEventList = snsEventRepository.findAllByWorkspace(foundWorkspace);
+        return SnsEventConverter.toGetSnsEventListRequest(snsEventList);
+    }
+
+    @Override
+    @TrackLastOpened(type = DocumentType.SNS_EVENT_ASSISTANT)
+    public SnsEventResponseDTO.GetSnsEventRequest getSnsEvent(Long userId, Long snsEventId) {
+        User foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new MemberHandler(MEMBER_NOT_FOUND));
+        SnsEvent foundSnsEvent = snsEventRepository.findById(snsEventId)
+                .orElseThrow(() -> new SnsEventHandler(SNS_EVENT_NOT_FOUND));
+        List<Participant> participantList = participantRepository.findAllBySnsEvent(foundSnsEvent);
+        List<Winner> winnerList = winnerRepository.findAllBySnsEvent(foundSnsEvent);
+        return SnsEventConverter.toGetSnsEventRequest(
+                foundSnsEvent,
+                participantList,
+                winnerList
+        );
+    }
+
+}

--- a/src/main/java/com/haru/api/global/annotation/LastOpenedAspect.java
+++ b/src/main/java/com/haru/api/global/annotation/LastOpenedAspect.java
@@ -1,0 +1,43 @@
+package com.haru.api.global.annotation;
+
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+import com.haru.api.domain.lastOpened.service.UserDocumentLastOpenedService;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Order(1)
+public class LastOpenedAspect {
+
+    private final UserDocumentLastOpenedService userDocumentLastOpenedService;
+
+    @Around("@annotation(trackLastOpened)")
+    public Object trackLastOpened(ProceedingJoinPoint joinPoint, TrackLastOpened trackLastOpened) throws Throwable {
+        // 실제 메서드 실행
+        Object result = joinPoint.proceed();
+
+        DocumentType type = trackLastOpened.type();
+        int userIdIndex = trackLastOpened.userIdIndex();
+        int documentIdIndex = trackLastOpened.documentIdIndex();
+
+        // 메서드의 인자에서 userId와 documentId 추출
+        Object[] args = joinPoint.getArgs();
+
+        // 인덱스를 사용하여 userId와 documentId 추출
+        Long userId = (Long) args[userIdIndex];
+        Long documentId = (Long) args[documentIdIndex];
+
+        if (userId != null && documentId != null) {
+            userDocumentLastOpenedService.updateLastOpened(userId, type, documentId);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/haru/api/global/annotation/TrackLastOpened.java
+++ b/src/main/java/com/haru/api/global/annotation/TrackLastOpened.java
@@ -1,0 +1,16 @@
+package com.haru.api.global.annotation;
+
+import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackLastOpened {
+    DocumentType type();
+    int userIdIndex() default 0;
+    int documentIdIndex() default 1;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #102

## 📝작업 내용
> 문서가 조회될 때 마다 last opened 업데이트 하도록 구현

## 🔎코드 설명(스크린샷(선택))
- AOP를 사용하여 커스텀 어노테이션이 붙은 메서드를 실행하면 해당 시간으로 last opened가 업데이트 되도록 구현
- SnsEvent 조회 기능 SnsEventCommandService에서 SnsEventQueryService로 이동

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X