### PR TITLE
feat/#139: 반정규화 테이블 수정 및 이에 따른 로직 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentId.java
@@ -16,6 +16,7 @@ import java.util.Objects;
 public class UserDocumentId implements Serializable {
 
     @Column(name = "user_id")
+    @Getter
     private Long userId;
 
     @Column(name = "document_id")
@@ -24,6 +25,7 @@ public class UserDocumentId implements Serializable {
 
     @Column(name = "document_type")
     @Enumerated(EnumType.STRING)
+    @Getter
     private DocumentType documentType;
 
 

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
@@ -28,6 +28,12 @@ public class UserDocumentLastOpened {
         foreignKey = @ForeignKey(name = "fk_user_document_user"))
     private User user;
 
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "workspace_id", nullable = false)
+    private Long workspaceId; // Workspace로 매핑하게 되면 추가적인 SELECT 쿼리 발생가능성 때문에 workspaceId만 저장하도록 설정
+
     @Column(name = "last_opened")
     private LocalDateTime lastOpened;
 

--- a/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/entity/UserDocumentLastOpened.java
@@ -1,6 +1,5 @@
 package com.haru.api.domain.lastOpened.entity;
 
-import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +9,11 @@ import org.hibernate.annotations.DynamicUpdate;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_document_last_opened")
+@Table(name = "user_document_last_opened",
+    indexes = {
+        @Index(name = "idx_workspace_user_last_opened",
+               columnList = "workspace_id, user_id, last_opened DESC")
+})
 @Getter
 @DynamicUpdate
 @DynamicInsert

--- a/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
@@ -4,8 +4,11 @@ import com.haru.api.domain.lastOpened.entity.UserDocumentId;
 import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserDocumentLastOpenedRepository extends JpaRepository<UserDocumentLastOpened, Long> {
     Optional<UserDocumentLastOpened> findById(UserDocumentId id);
+
+    List<UserDocumentLastOpened> findTop5ByWorkspaceIdAndUserIdOrderByLastOpenedDesc(Long workspaceId, Long userId);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/repository/UserDocumentLastOpenedRepository.java
@@ -3,6 +3,7 @@ package com.haru.api.domain.lastOpened.repository;
 import com.haru.api.domain.lastOpened.entity.UserDocumentId;
 import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +12,11 @@ public interface UserDocumentLastOpenedRepository extends JpaRepository<UserDocu
     Optional<UserDocumentLastOpened> findById(UserDocumentId id);
 
     List<UserDocumentLastOpened> findTop5ByWorkspaceIdAndUserIdOrderByLastOpenedDesc(Long workspaceId, Long userId);
+
+    @Query("SELECT udlo " +
+            "FROM UserDocumentLastOpened udlo " +
+            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.userId = :userId " +
+            "AND udlo.title LIKE %:title% " +
+            "ORDER BY udlo.lastOpened DESC")
+    List<UserDocumentLastOpened> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedService.java
@@ -4,5 +4,5 @@ import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 
 public interface UserDocumentLastOpenedService {
 
-    void updateLastOpened(Long userId, DocumentType documentType, Long documentId);
+    void updateLastOpened(Long userId, DocumentType documentType, Long documentId, Long workspaceId, String title);
 }

--- a/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/lastOpened/service/UserDocumentLastOpenedServiceImpl.java
@@ -25,7 +25,7 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
 
     @Override
     @Transactional
-    public void updateLastOpened(Long userId, DocumentType documentType, Long documentId) {
+    public void updateLastOpened(Long userId, DocumentType documentType, Long documentId, Long workspaceId, String title) {
         UserDocumentId id = new UserDocumentId(userId, documentId, documentType);
 
         UserDocumentLastOpened record = userDocumentLastOpenedRepository.findById(id)
@@ -35,13 +35,15 @@ public class UserDocumentLastOpenedServiceImpl implements UserDocumentLastOpened
                     return UserDocumentLastOpened.builder()
                             .id(id)
                             .user(foundUser)
+                            .workspaceId(workspaceId)
+                            .title(title)
                             .build();
                 });
 
         record.updateLastOpened(LocalDateTime.now());
         userDocumentLastOpenedRepository.save(record);
 
-        log.info("userDocumentLastOpened updated for userId: {}. documentId:{}", record.getUser().getId(), record.getId().getDocumentId());
+        log.info("userDocumentLastOpened updated for userId: {}, documentId:{}, workspaceId:{}, title:{}", record.getUser().getId(), record.getId().getDocumentId(), workspaceId, title);
     }
 
 }

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -18,15 +18,13 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
             "udlo.id.documentId, " +
-            "mt.title, " +
+            "udlo.title, " +
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
             "FROM UserDocumentLastOpened udlo " +
-            "JOIN Meeting mt ON udlo.id.documentId = mt.id " +
-            "WHERE mt.workspace.id = :workspaceId AND udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
-            "AND (:title IS NULL OR :title = '' OR mt.title LIKE %:title%)")
+            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
+            "AND (:title IS NULL OR :title = '' OR udlo.title LIKE %:title%)")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
-
 
     @Query("SELECT m.workspace FROM Meeting m WHERE m.id = :meetingId")
     Optional<Workspace> findWorkspaceByMeetingId(@Param("meetingId") Long meetingId);

--- a/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/haru/api/domain/meeting/repository/MeetingRepository.java
@@ -16,16 +16,6 @@ import java.util.Optional;
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
     List<Meeting> findByWorkspaceOrderByUpdatedAtDesc(Workspace workspace);
 
-    @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
-            "udlo.id.documentId, " +
-            "udlo.title, " +
-            "udlo.id.documentType, " +
-            "udlo.lastOpened) " +
-            "FROM UserDocumentLastOpened udlo " +
-            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.documentType = 'AI_MEETING_MANAGER' AND udlo.user.id = :userId " +
-            "AND (:title IS NULL OR :title = '' OR udlo.title LIKE %:title%)")
-    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
-
     @Query("SELECT m.workspace FROM Meeting m WHERE m.id = :meetingId")
     Optional<Workspace> findWorkspaceByMeetingId(@Param("meetingId") Long meetingId);
 

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -16,16 +16,6 @@ import java.util.Optional;
 public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> {
     List<MoodTracker> findAllByWorkspaceId(Long workspaceId);
 
-    @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
-            "udlo.id.documentId, " +
-            "udlo.title, " +
-            "udlo.id.documentType, " +
-            "udlo.lastOpened) " +
-            "FROM UserDocumentLastOpened udlo " +
-            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
-            "AND (:title IS NULL OR :title = '' OR udlo.title LIKE %:title%)")
-    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
-
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$DocumentCalendar(" +
             "mt.id, " +
             "mt.title, " +

--- a/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
+++ b/src/main/java/com/haru/api/domain/moodTracker/repository/MoodTrackerRepository.java
@@ -2,12 +2,15 @@ package com.haru.api.domain.moodTracker.repository;
 
 import com.haru.api.domain.moodTracker.entity.MoodTracker;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
+import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> {
@@ -15,13 +18,12 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
             "udlo.id.documentId, " +
-            "mt.title, " +
+            "udlo.title, " +
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
-            "FROM UserDocumentLastOpened  udlo " +
-            "JOIN MoodTracker mt ON udlo.id.documentId = mt.id " +
-            "WHERE mt.workspace.id = :workspaceId AND udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
-            "AND (:title IS NULL OR :title = '' OR mt.title LIKE %:title%)")
+            "FROM UserDocumentLastOpened udlo " +
+            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.documentType = 'TEAM_MOOD_TRACKER' AND udlo.user.id = :userId " +
+            "AND (:title IS NULL OR :title = '' OR udlo.title LIKE %:title%)")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$DocumentCalendar(" +
@@ -33,4 +35,5 @@ public interface MoodTrackerRepository extends JpaRepository<MoodTracker, Long> 
             "WHERE mt.workspace.id = :workspaceId " +
             "AND mt.createdAt BETWEEN :startDate AND :endDate")
     List<WorkspaceResponseDTO.DocumentCalendar> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -5,23 +5,24 @@ import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.entity.Workspace;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
 
     @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
             "udlo.id.documentId, " +
-            "se.title, " +
+            "udlo.title, " +
             "udlo.id.documentType, " +
             "udlo.lastOpened) " +
-            "FROM UserDocumentLastOpened  udlo " +
-            "JOIN SnsEvent se ON udlo.id.documentId = se.id " +
-            "WHERE se.workspace.id = :workspaceId AND udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
-            "AND (:title IS NULL OR :title = '' OR se.title LIKE %:title%)")
+            "FROM UserDocumentLastOpened udlo " +
+            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
+            "AND (:title IS NULL OR :title = '' OR udlo.title LIKE %:title%)")
     List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
 
     List<SnsEvent> findAllByWorkspaceId(Long workspaceId);
@@ -37,5 +38,6 @@ public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
             "WHERE se.workspace.id = :workspaceId " +
             "AND se.createdAt BETWEEN :startDate AND :endDate")
     List<WorkspaceResponseDTO.DocumentCalendar> findAllDocumentForCalendars(Long workspaceId, LocalDateTime startDate, LocalDateTime endDate);
+
 
 }

--- a/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
+++ b/src/main/java/com/haru/api/domain/snsEvent/repository/SnsEventRepository.java
@@ -15,16 +15,6 @@ import java.util.Optional;
 @Repository
 public interface SnsEventRepository extends JpaRepository<SnsEvent, Long> {
 
-    @Query("SELECT new com.haru.api.domain.workspace.dto.WorkspaceResponseDTO$Document(" +
-            "udlo.id.documentId, " +
-            "udlo.title, " +
-            "udlo.id.documentType, " +
-            "udlo.lastOpened) " +
-            "FROM UserDocumentLastOpened udlo " +
-            "WHERE udlo.workspaceId = :workspaceId AND udlo.id.documentType = 'SNS_EVENT_ASSISTANT' AND udlo.user.id = :userId " +
-            "AND (:title IS NULL OR :title = '' OR udlo.title LIKE %:title%)")
-    List<WorkspaceResponseDTO.Document> findRecentDocumentsByTitle(Long workspaceId, Long userId, String title);
-
     List<SnsEvent> findAllByWorkspaceId(Long workspaceId);
 
     List<SnsEvent> findAllByWorkspace(Workspace foundWorkspace);

--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -15,7 +15,16 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    public static WorkspaceResponseDTO.DocumentList toDocumentsDTO(List<WorkspaceResponseDTO.Document> documentList) {
+    public static WorkspaceResponseDTO.Document toDocument(UserDocumentLastOpened document) {
+        return WorkspaceResponseDTO.Document.builder()
+                .documentId(document.getId().getDocumentId())
+                .title(document.getTitle())
+                .documentType(document.getId().getDocumentType())
+                .lastOpened(document.getLastOpened())
+                .build();
+    }
+
+    public static WorkspaceResponseDTO.DocumentList toDocumentList(List<WorkspaceResponseDTO.Document> documentList) {
         return WorkspaceResponseDTO.DocumentList.builder()
                 .documents(documentList)
                 .build();

--- a/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
+++ b/src/main/java/com/haru/api/domain/workspace/converter/WorkspaceConverter.java
@@ -1,5 +1,6 @@
 package com.haru.api.domain.workspace.converter;
 
+import com.haru.api.domain.lastOpened.entity.UserDocumentLastOpened;
 import com.haru.api.domain.workspace.dto.WorkspaceResponseDTO;
 import com.haru.api.domain.workspace.entity.Workspace;
 
@@ -28,15 +29,15 @@ public class WorkspaceConverter {
                 .build();
     }
 
-    public static WorkspaceResponseDTO.DocumentSidebar toDocumentWithoutLastOpened(WorkspaceResponseDTO.Document document) {
+    public static WorkspaceResponseDTO.DocumentSidebar toDocumentSidebar(UserDocumentLastOpened document) {
         return WorkspaceResponseDTO.DocumentSidebar.builder()
-                .documentId(document.getDocumentId())
-                .documentType(document.getDocumentType())
+                .documentId(document.getId().getDocumentId())
+                .documentType(document.getId().getDocumentType())
                 .title(document.getTitle())
                 .build();
     }
 
-    public static WorkspaceResponseDTO.DocumentSidebarList toDocumentWithoutLastOpenedList(List<WorkspaceResponseDTO.DocumentSidebar> documentList) {
+    public static WorkspaceResponseDTO.DocumentSidebarList toDocumentSidebarList(List<WorkspaceResponseDTO.DocumentSidebar> documentList) {
         return WorkspaceResponseDTO.DocumentSidebarList.builder()
                 .documents(documentList)
                 .build();

--- a/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryServiceImpl.java
+++ b/src/main/java/com/haru/api/domain/workspace/service/WorkspaceQueryServiceImpl.java
@@ -50,27 +50,13 @@ public class WorkspaceQueryServiceImpl implements WorkspaceQueryService {
         if (!userWorkspaceRepository.existsByWorkspaceIdAndUserId(workspaceId, userId))
             throw new WorkspaceHandler(ErrorStatus.NOT_BELONG_TO_WORKSPACE);
 
-        // workspace에 속해있는 각 문서별로 title이 일치하는 문서 검색
-        List<WorkspaceResponseDTO.Document> meetingList = meetingRepository.findRecentDocumentsByTitle(workspaceId, foundUser.getId(), title);
-        List<WorkspaceResponseDTO.Document> snsEventList = snsEventRepository.findRecentDocumentsByTitle(workspaceId, foundUser.getId(), title);
-        List<WorkspaceResponseDTO.Document> moodTrackerList = moodTrackerRepository.findRecentDocumentsByTitle(workspaceId, foundUser.getId(), title);
+        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedRepository.findRecentDocumentsByTitle(workspaceId, userId, title);
 
-        // 모든 문서 리스트 스트림으로 합침
-        List<WorkspaceResponseDTO.Document> allResults = new ArrayList<>();
-        allResults.addAll(meetingList);
-        allResults.addAll(snsEventList);
-        allResults.addAll(moodTrackerList);
-
-        // last_opened가 null인 경우에는 가장 뒤로 보내기
-        // last_opened가 모두 null인 경우에도 동작하도록 구현
-        List<WorkspaceResponseDTO.Document> finalResult = allResults.stream()
-                .sorted(Comparator.comparing(WorkspaceResponseDTO.Document::getLastOpened,
-                                            Comparator.nullsLast(Comparator.naturalOrder()))
-                                    .reversed())
-                .toList();
-
-        return WorkspaceConverter.toDocumentsDTO(finalResult);
-
+        return WorkspaceConverter.toDocumentList(
+                documentList.stream()
+                        .map(WorkspaceConverter::toDocument)
+                        .toList()
+        );
     }
 
     @Transactional(readOnly = true)
@@ -90,10 +76,10 @@ public class WorkspaceQueryServiceImpl implements WorkspaceQueryService {
             throw new WorkspaceHandler(ErrorStatus.NOT_BELONG_TO_WORKSPACE);
 
         // 유저가 가장 최근에 조회한 문서 5개 추출
-        List<UserDocumentLastOpened> lastOpenedList = userDocumentLastOpenedRepository.findTop5ByWorkspaceIdAndUserIdOrderByLastOpenedDesc(workspaceId, userId);
+        List<UserDocumentLastOpened> documentList = userDocumentLastOpenedRepository.findTop5ByWorkspaceIdAndUserIdOrderByLastOpenedDesc(workspaceId, userId);
 
         return WorkspaceConverter.toDocumentSidebarList(
-                lastOpenedList.stream()
+                documentList.stream()
                         .map(WorkspaceConverter::toDocumentSidebar)
                         .toList()
         );

--- a/src/main/java/com/haru/api/global/annotation/LastOpenedAspect.java
+++ b/src/main/java/com/haru/api/global/annotation/LastOpenedAspect.java
@@ -2,6 +2,16 @@ package com.haru.api.global.annotation;
 
 import com.haru.api.domain.lastOpened.entity.enums.DocumentType;
 import com.haru.api.domain.lastOpened.service.UserDocumentLastOpenedService;
+import com.haru.api.domain.meeting.entity.Meeting;
+import com.haru.api.domain.meeting.repository.MeetingRepository;
+import com.haru.api.domain.moodTracker.entity.MoodTracker;
+import com.haru.api.domain.moodTracker.repository.MoodTrackerRepository;
+import com.haru.api.domain.snsEvent.entity.SnsEvent;
+import com.haru.api.domain.snsEvent.repository.SnsEventRepository;
+import com.haru.api.global.apiPayload.code.status.ErrorStatus;
+import com.haru.api.global.apiPayload.exception.handler.MeetingHandler;
+import com.haru.api.global.apiPayload.exception.handler.MoodTrackerHandler;
+import com.haru.api.global.apiPayload.exception.handler.SnsEventHandler;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -16,6 +26,9 @@ import org.springframework.stereotype.Component;
 public class LastOpenedAspect {
 
     private final UserDocumentLastOpenedService userDocumentLastOpenedService;
+    private final MeetingRepository meetingRepository;
+    private final SnsEventRepository snsEventRepository;
+    private final MoodTrackerRepository moodTrackerRepository;
 
     @Around("@annotation(trackLastOpened)")
     public Object trackLastOpened(ProceedingJoinPoint joinPoint, TrackLastOpened trackLastOpened) throws Throwable {
@@ -34,7 +47,28 @@ public class LastOpenedAspect {
         Long documentId = (Long) args[documentIdIndex];
 
         if (userId != null && documentId != null) {
-            userDocumentLastOpenedService.updateLastOpened(userId, type, documentId);
+            // document type에 따라 조회하는 repository 구분하여 workspaceId, title 추출
+            Long workspaceId = null;
+            String title = null;
+
+            if(type.equals(DocumentType.AI_MEETING_MANAGER)) {
+                Meeting foundMeeting = meetingRepository.findById(documentId)
+                        .orElseThrow(() -> new MeetingHandler(ErrorStatus.MEETING_NOT_FOUND));
+                workspaceId = foundMeeting.getWorkspace().getId();
+                title = foundMeeting.getTitle();
+            } else if(type.equals(DocumentType.SNS_EVENT_ASSISTANT)) {
+                SnsEvent foundSnsEvent = snsEventRepository.findById(documentId)
+                        .orElseThrow(() -> new SnsEventHandler(ErrorStatus.SNS_EVENT_NOT_FOUND));
+                workspaceId = foundSnsEvent.getWorkspace().getId();
+                title = foundSnsEvent.getTitle();
+            } else {
+                MoodTracker foundMoodTracker = moodTrackerRepository.findById(documentId)
+                        .orElseThrow(() -> new MoodTrackerHandler(ErrorStatus.MOOD_TRACKER_NOT_FOUND));
+                workspaceId = foundMoodTracker.getWorkspace().getId();
+                title = foundMoodTracker.getTitle();
+            }
+
+            userDocumentLastOpenedService.updateLastOpened(userId, type, documentId, workspaceId, title);
         }
 
         return result;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #139

## 📝작업 내용
> 반정규화 테이블 수정 및 이에 따른 로직 수정

## 🔎코드 설명(스크린샷(선택))
- 반정규화 테이블에 title, workspaceId 컬럼을 추가
- 문서를 검색하거나, 최근 문서를 조회할 때 다른 테이블과의 JOIN 없이 UserDocumentLastOpened만 조회하면 되도록 구현
- workspaceId, userId, last_opened에 대한 복합 인덱스 생성 및 적용하여 최근 문서를 조회할 때 성능 향상

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X