### PR TITLE
feat/#141: 유저 정보 수정 API 수정

### DIFF
--- a/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/com/haru/api/domain/user/dto/UserRequestDTO.java
@@ -39,7 +39,7 @@ public class UserRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UserInfoUpdateRequest {
-        @NotBlank(message = "이름은 빈 값일 수 없습니다.")
         private String name;
+        private String password;
     }
 }

--- a/src/main/java/com/haru/api/domain/user/entity/User.java
+++ b/src/main/java/com/haru/api/domain/user/entity/User.java
@@ -46,4 +46,8 @@ public class User extends BaseEntity {
     public void updateName(String name) {
         this.name = name;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/haru/api/global/apiPayload/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 존재하는 회원입니다."),
     MEMBER_USERNAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4005", "해당 아이디를 가진 유저가 존재하지 않습니다."), //
     MEMBER_PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "MEMBER4006", "비밀번호가 일치하지 않습니다."),
+    SAME_WITH_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4007", "변경하고자하는 비밀번호와 이전 비밀번호가 일치합니다."),
 
     // Workspace 관련 에러
     WORKSPACE_NOT_FOUND(HttpStatus.BAD_REQUEST,"WORKSPACE4001", "워크스페이스가 없습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> #141

## 📝작업 내용
> 유저 정보 수정 API 수정

## 🔎코드 설명(스크린샷(선택))
- 유저 정보 수정할 때 name, password 수정할 수 있도록 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> X

## 비고 (Optional)
> X