### PR TITLE
feat/#164: 구글 로그인 후 리다이렉트 되는 프론트엔드 URI 코드에 추가 및 Query Parameter의 status로 구글 로그인 성공 실패 구분

### DIFF
--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2FailureHandler.java
@@ -16,9 +16,8 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
             HttpServletResponse response,
             AuthenticationException exception
     ) throws IOException {
-        String errorMessage = "google_oauth_login_failed";
-        String failureGoogleLoginUrl = "";
+        String failureGoogleLoginUrl = "/auth/login/google/callback";
         // 프론트엔드 URL로 리다이렉트 (query param 전달)
-        response.sendRedirect("http://localhost:3000" + failureGoogleLoginUrl + "?error=" + errorMessage);
+        response.sendRedirect("http://localhost:3000" + failureGoogleLoginUrl + "?status=fail");
     }
 }

--- a/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/haru/api/domain/user/security/googleOauth2/CustomOAuth2SuccessHandler.java
@@ -27,7 +27,7 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             HttpServletResponse response,
             Authentication authentication
     ) throws IOException {
-        String successGoogleLoginUrl = "";
+        String successGoogleLoginUrl = "/auth/login/google/callback";
         CustomOauth2UserDetails userDetails = (CustomOauth2UserDetails) authentication.getPrincipal();
         if (!userDetails.getIsNewUser()) { // 회원가입인지 로그인인지 판단, 로그인이면 토큰 반환
             Long userId = userDetails.getUser().getId();
@@ -35,10 +35,9 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             String accessToken = userCommandService.generateAccessToken(userId, accessExpTime);
             String refreshToken = userCommandService.generateAndSaveRefreshToken(key, refreshExpTime);
             // 프론트엔드 URL로 리다이렉트 (query param 전달)
-            response.sendRedirect("http://localhost:3000" + successGoogleLoginUrl + "?accessToken=" + accessToken + "&refreshToken=" + refreshToken);
+            response.sendRedirect("http://localhost:3000" + successGoogleLoginUrl + "?status=success" + "&accessToken=" + accessToken + "&refreshToken=" + refreshToken);
         } else { // 회원가입
-            response.sendRedirect("http://localhost:3000" + successGoogleLoginUrl);
+            response.sendRedirect("http://localhost:3000" + successGoogleLoginUrl + "?status=success");
         }
-
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #164

## 📝작업 내용
> 구글 로그인 후 리다이렉트 되는 프론트엔드 URI 코드에 추가
> Query Parameter의 status로 구글 로그인 성공 실패 구분

## 🔎코드 설명(스크린샷(선택))
> 구글 로그인 이후 Spring Security에서 실행하는 CustomOAuth2SuccessHandler와 CustomOAuth2FailureHandler에서 처리

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
