### PR TITLE
feat/#179: 구글 로그인위한 redirect-uri을 인가처리에서 제외

### DIFF
--- a/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/haru/api/domain/user/security/jwt/JwtAuthenticationFilter.java
@@ -39,7 +39,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/workspaces/invite-accept",
             "/api/v1/terms",
             "/api/v1/sns/oauth/callback",
-            "/api/v1/users/signup/same"
+            "/api/v1/users/signup/same",
+            "login/oauth2/code/google"
     };
     private final JwtUtils jwtUtils;
     private final RedisTemplate<String, String> redisTemplate;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #179

## 📝작업 내용
> 구글 로그인위한 redirect-uri을 인가처리에서 제외

## 🔎코드 설명(스크린샷(선택))
> 구글 로그인위한 redirect-uri을 인가처리에서 제외시키기위해 JwtAuthenticationFilter의 whitelist에 redirect-uri추가

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
